### PR TITLE
Remove always-blocked commands, focus on boundary only

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Allows destructive operations **within your project** but blocks them **outside*
 | `wget -O` / `wget --output-document` | Allowed | **Blocked** |
 | `find -delete` / `find -exec rm` | Allowed | **Blocked** |
 | `dd of=` | Allowed | **Blocked** |
+| `install` (source and destination) | Allowed | **Blocked** |
+| `rsync` (source and destination) | Allowed | **Blocked** |
+| `tar -C` / `--directory=` | Allowed | **Blocked** |
+| `unzip -d` / `cpio -D` | Allowed | **Blocked** |
 | **Edit** tool (file edits) | Allowed | **Blocked** |
 | **MultiEdit** tool (multi-file edits) | Allowed | **Blocked** |
 | **Write** tool (file creation) | Allowed | **Blocked** |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Allows destructive operations **within your project** but blocks them **outside*
 ### Additional protections
 
 - **Chained commands** — splits on `;`, `&&`, `||`, `|` and checks each sub-command independently
-- **`cd` tracking** — `cd /tmp && rm -rf something` is blocked because `cd` left the project; also blocks `git`, `rails`, `rake` after `cd` outside
+- **`cwd` awareness** — uses `cwd` from the hook event, so commands run outside the project (without an explicit `cd`) are also guarded
+- **`cd` tracking** — `cd /tmp && rm -rf something` is blocked because `cd` left the project; `cd $PROJECT && rm file` is allowed even if the event `cwd` was outside
+- **Destructive subcommands outside project** — when running outside the project (via event `cwd` or `cd`), these are blocked: `git clean -f`, `git checkout .`, `git restore .`, `git reset --hard`, `git push --force`, `git stash drop/clear`, `git branch -D`, `git reflog expire`, `rails db:drop/reset`, `rake db:drop/reset`. Safe commands like `git status`, `git log`, `rails routes` remain allowed.
 - **`sudo` prefix** — stripped before checking, so `sudo rm /etc/passwd` is still blocked
 - **`find` options** — handles `-L`, `-H`, `-P` before the search path
 - **Path traversal** — `..` segments are resolved before boundary check

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Allows destructive operations **within your project** but blocks them **outside*
 | `curl -o` / `curl --output` | Allowed | **Blocked** |
 | `wget -O` / `wget --output-document` | Allowed | **Blocked** |
 | `find -delete` / `find -exec rm` | Allowed | **Blocked** |
+| `dd of=` | Allowed | **Blocked** |
 | **Edit** tool (file edits) | Allowed | **Blocked** |
 | **MultiEdit** tool (multi-file edits) | Allowed | **Blocked** |
 | **Write** tool (file creation) | Allowed | **Blocked** |

--- a/README.md
+++ b/README.md
@@ -10,20 +10,6 @@ Allows destructive operations **within your project** but blocks them **outside*
 
 ## What it does
 
-### Always blocked (regardless of location)
-
-| Command | Example |
-|---------|---------|
-| `git push --force` / `-f` | `git push --force origin main` |
-| `git reset --hard` | `git reset --hard HEAD~1` |
-| `git checkout .` | `git checkout .` |
-| `git clean -f` | `git clean -fd` |
-| `DROP TABLE` / `TRUNCATE TABLE` | `DROP TABLE users;` |
-| `rails db:drop` / `db:reset` | `rails db:drop` |
-| `rake db:drop` / `db:reset` | `rake db:drop` |
-| `mkfs.*` | `mkfs.ext4 /dev/sda1` |
-| `dd if=` | `dd if=/dev/zero of=/dev/sda` |
-
 ### Boundary-checked (allowed inside project, blocked outside)
 
 | Operation | Inside project | Outside project |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Allows destructive operations **within your project** but blocks them **outside*
 ### Additional protections
 
 - **Chained commands** — splits on `;`, `&&`, `||`, `|` and checks each sub-command independently
-- **`cd` tracking** — `cd /tmp && rm -rf something` is blocked because `cd` left the project
+- **`cd` tracking** — `cd /tmp && rm -rf something` is blocked because `cd` left the project; also blocks `git`, `rails`, `rake` after `cd` outside
 - **`sudo` prefix** — stripped before checking, so `sudo rm /etc/passwd` is still blocked
 - **`find` options** — handles `-L`, `-H`, `-P` before the search path
 - **Path traversal** — `..` segments are resolved before boundary check

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -175,7 +175,7 @@ check_single_command() {
 
   # If a previous cd went outside project, block any destructive command
   if [[ "${_GUARD_CD_OUTSIDE:-0}" == "1" ]]; then
-    local destructive_cmds="rm|mv|cp|ln|chmod|chown|tee|find|curl|wget"
+    local destructive_cmds="rm|mv|cp|ln|chmod|chown|tee|find|curl|wget|git|rails|rake"
     if echo "$CMD" | grep -qE "(^|[[:space:]])($destructive_cmds)($|[[:space:]])"; then
       echo "BLOCKED: Destructive command after 'cd' outside project directory. Ask user for explicit permission." >&2
       exit 2

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -213,10 +213,19 @@ check_single_command() {
       exit 2
     fi
     # Destructive git subcommands
-    # git clean is destructive unless -n or --dry-run is present
+    # git clean only destructive with -f/--force AND without -n/--dry-run
     if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+clean([[:space:]]|$)'; then
-      if ! echo "$CMD" | grep -qE '(^|[[:space:]])(-n|--dry-run)([[:space:]]|$)' && \
-         ! echo "$CMD" | grep -qE '(^|[[:space:]])-[a-zA-Z]*n[a-zA-Z]*([[:space:]]|$)'; then
+      local has_force=0
+      local is_dry_run=0
+      if echo "$CMD" | grep -qE '(^|[[:space:]])--force([[:space:]]|$)' || \
+         echo "$CMD" | grep -qE '(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)'; then
+        has_force=1
+      fi
+      if echo "$CMD" | grep -qE '(^|[[:space:]])--dry-run([[:space:]]|$)' || \
+         echo "$CMD" | grep -qE '(^|[[:space:]])-[a-zA-Z]*n[a-zA-Z]*([[:space:]]|$)'; then
+        is_dry_run=1
+      fi
+      if [[ "$has_force" == "1" && "$is_dry_run" == "0" ]]; then
         echo "BLOCKED: Destructive 'git clean' outside project directory. Ask user for explicit permission." >&2
         exit 2
       fi

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -4,9 +4,18 @@ set -euo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+EVENT_CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
 if [ -z "$COMMAND" ] && [ -z "$FILE_PATH" ]; then
   exit 0
+fi
+
+# Use cwd from the hook event if provided, so relative paths resolve correctly.
+# EFFECTIVE_CWD is used to resolve relative paths in commands.
+if [ -n "$EVENT_CWD" ]; then
+  EFFECTIVE_CWD="$EVENT_CWD"
+else
+  EFFECTIVE_CWD=""
 fi
 
 # If CLAUDE_PROJECT_DIR is not set, fall back to pwd with a warning.
@@ -18,6 +27,12 @@ fi
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 # Ensure PROJECT_DIR has no trailing slash for consistent comparison
 PROJECT_DIR="${PROJECT_DIR%/}"
+
+# EFFECTIVE_CWD: where relative paths in commands resolve to.
+# Uses cwd from hook event if provided, otherwise PROJECT_DIR.
+if [ -z "$EFFECTIVE_CWD" ]; then
+  EFFECTIVE_CWD="$PROJECT_DIR"
+fi
 
 # --- Portable realpath in pure bash ---
 # macOS realpath does not support -m (non-existent path resolution).
@@ -162,7 +177,7 @@ check_single_command() {
       cd_target=$(expand_path "$cd_target")
     fi
     if [[ "$cd_target" != /* ]]; then
-      cd_target="$PROJECT_DIR/$cd_target"
+      cd_target="$EFFECTIVE_CWD/$cd_target"
     fi
     local resolved_cd
     resolved_cd=$(resolve_path "$cd_target")
@@ -175,9 +190,19 @@ check_single_command() {
 
   # If a previous cd went outside project, block any destructive command
   if [[ "${_GUARD_CD_OUTSIDE:-0}" == "1" ]]; then
-    local destructive_cmds="rm|mv|cp|ln|chmod|chown|tee|find|curl|wget|git|rails|rake"
+    local destructive_cmds="rm|mv|cp|ln|chmod|chown|tee|find|curl|wget|dd"
     if echo "$CMD" | grep -qE "(^|[[:space:]])($destructive_cmds)($|[[:space:]])"; then
       echo "BLOCKED: Destructive command after 'cd' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # Destructive git subcommands
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+(clean|checkout[[:space:]]+\.|reset[[:space:]]+--hard|push[[:space:]]+.*(-f|--force))'; then
+      echo "BLOCKED: Destructive git command after 'cd' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # Destructive rails/rake subcommands
+    if echo "$CMD" | grep -qE '(^|[[:space:]])(rails|rake)[[:space:]]+db:(drop|reset)'; then
+      echo "BLOCKED: Destructive rails/rake command after 'cd' outside project directory. Ask user for explicit permission." >&2
       exit 2
     fi
   fi
@@ -257,7 +282,7 @@ check_single_command() {
       for find_path in "${find_paths[@]}"; do
         find_path=$(expand_path "$find_path")
         if [[ "$find_path" != /* ]]; then
-          find_path="$PROJECT_DIR/$find_path"
+          find_path="$EFFECTIVE_CWD/$find_path"
         fi
         local resolved_find
         resolved_find=$(resolve_path "$find_path")
@@ -278,7 +303,7 @@ check_single_command() {
       TARGET=$(expand_path "$TARGET")
       # Resolve to absolute path
       if [[ "$TARGET" != /* ]]; then
-        TARGET="$PROJECT_DIR/$TARGET"
+        TARGET="$EFFECTIVE_CWD/$TARGET"
       fi
       RESOLVED=$(resolve_path "$TARGET")
 
@@ -302,7 +327,7 @@ check_single_command() {
     mv_target_dir=$(echo "$CMD" | grep -oE '\-\-target-directory=[^ ]+' | sed 's/--target-directory=//' || true)
     if [ -n "$mv_target_dir" ]; then
       mv_target_dir=$(expand_path "$mv_target_dir")
-      [[ "$mv_target_dir" != /* ]] && mv_target_dir="$PROJECT_DIR/$mv_target_dir"
+      [[ "$mv_target_dir" != /* ]] && mv_target_dir="$EFFECTIVE_CWD/$mv_target_dir"
       local resolved_mv_td
       resolved_mv_td=$(resolve_path "$mv_target_dir")
       if ! is_inside_project "$resolved_mv_td"; then
@@ -315,7 +340,7 @@ check_single_command() {
     for TARGET in $MV_ARGS; do
       TARGET=$(expand_path "$TARGET")
       if [[ "$TARGET" != /* ]]; then
-        TARGET="$PROJECT_DIR/$TARGET"
+        TARGET="$EFFECTIVE_CWD/$TARGET"
       fi
       RESOLVED=$(resolve_path "$TARGET")
 
@@ -333,7 +358,7 @@ check_single_command() {
     cp_target_dir=$(echo "$CMD" | grep -oE '\-\-target-directory=[^ ]+' | sed 's/--target-directory=//' || true)
     if [ -n "$cp_target_dir" ]; then
       cp_target_dir=$(expand_path "$cp_target_dir")
-      [[ "$cp_target_dir" != /* ]] && cp_target_dir="$PROJECT_DIR/$cp_target_dir"
+      [[ "$cp_target_dir" != /* ]] && cp_target_dir="$EFFECTIVE_CWD/$cp_target_dir"
       local resolved_cp_td
       resolved_cp_td=$(resolve_path "$cp_target_dir")
       if ! is_inside_project "$resolved_cp_td"; then
@@ -346,7 +371,7 @@ check_single_command() {
     for TARGET in $CP_ARGS; do
       TARGET=$(expand_path "$TARGET")
       if [[ "$TARGET" != /* ]]; then
-        TARGET="$PROJECT_DIR/$TARGET"
+        TARGET="$EFFECTIVE_CWD/$TARGET"
       fi
       RESOLVED=$(resolve_path "$TARGET")
 
@@ -364,7 +389,7 @@ check_single_command() {
     for TARGET in $LN_ARGS; do
       TARGET=$(expand_path "$TARGET")
       if [[ "$TARGET" != /* ]]; then
-        TARGET="$PROJECT_DIR/$TARGET"
+        TARGET="$EFFECTIVE_CWD/$TARGET"
       fi
       RESOLVED=$(resolve_path "$TARGET")
 
@@ -382,7 +407,7 @@ check_single_command() {
     for TARGET in $TEE_ARGS; do
       TARGET=$(expand_path "$TARGET")
       if [[ "$TARGET" != /* ]]; then
-        TARGET="$PROJECT_DIR/$TARGET"
+        TARGET="$EFFECTIVE_CWD/$TARGET"
       fi
       RESOLVED=$(resolve_path "$TARGET")
 
@@ -407,7 +432,7 @@ check_single_command() {
     if [ -n "$curl_output" ]; then
       curl_output=$(expand_path "$curl_output")
       if [[ "$curl_output" != /* ]]; then
-        curl_output="$PROJECT_DIR/$curl_output"
+        curl_output="$EFFECTIVE_CWD/$curl_output"
       fi
       local resolved_curl
       resolved_curl=$(resolve_path "$curl_output")
@@ -431,12 +456,30 @@ check_single_command() {
     if [ -n "$wget_output" ]; then
       wget_output=$(expand_path "$wget_output")
       if [[ "$wget_output" != /* ]]; then
-        wget_output="$PROJECT_DIR/$wget_output"
+        wget_output="$EFFECTIVE_CWD/$wget_output"
       fi
       local resolved_wget
       resolved_wget=$(resolve_path "$wget_output")
       if ! is_inside_project "$resolved_wget"; then
         echo "BLOCKED: 'wget' output file '$resolved_wget' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    fi
+  fi
+
+  # --- dd of= outside project ---
+  if echo "$CMD" | grep -qE '(^|[[:space:]])dd($|[[:space:]])'; then
+    local dd_output=""
+    dd_output=$(echo "$CMD" | grep -oE 'of=[^ ]+' | sed 's/^of=//')
+    if [ -n "$dd_output" ]; then
+      dd_output=$(expand_path "$dd_output")
+      if [[ "$dd_output" != /* ]]; then
+        dd_output="$EFFECTIVE_CWD/$dd_output"
+      fi
+      local resolved_dd
+      resolved_dd=$(resolve_path "$dd_output")
+      if ! is_inside_project "$resolved_dd"; then
+        echo "BLOCKED: 'dd' output '$resolved_dd' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
     fi
@@ -449,7 +492,7 @@ check_single_command() {
     if [ -n "$REDIR_TARGET" ]; then
       REDIR_TARGET=$(expand_path "$REDIR_TARGET")
       if [[ "$REDIR_TARGET" != /* ]]; then
-        REDIR_TARGET="$PROJECT_DIR/$REDIR_TARGET"
+        REDIR_TARGET="$EFFECTIVE_CWD/$REDIR_TARGET"
       fi
       RESOLVED=$(resolve_path "$REDIR_TARGET")
 
@@ -479,7 +522,7 @@ check_single_command() {
       for TARGET in $PATHS; do
         TARGET=$(expand_path "$TARGET")
         if [[ "$TARGET" != /* ]]; then
-          TARGET="$PROJECT_DIR/$TARGET"
+          TARGET="$EFFECTIVE_CWD/$TARGET"
         fi
         RESOLVED=$(resolve_path "$TARGET")
 

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -213,8 +213,27 @@ check_single_command() {
       exit 2
     fi
     # Destructive git subcommands
-    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+(clean|checkout[[:space:]]+\.|reset[[:space:]]+--hard|push[[:space:]]+.*(-f|--force))'; then
-      echo "BLOCKED: Destructive git command outside project directory. Ask user for explicit permission." >&2
+    # git clean is destructive unless -n or --dry-run is present
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+clean([[:space:]]|$)'; then
+      if ! echo "$CMD" | grep -qE '(^|[[:space:]])(-n|--dry-run)([[:space:]]|$)' && \
+         ! echo "$CMD" | grep -qE '(^|[[:space:]])-[a-zA-Z]*n[a-zA-Z]*([[:space:]]|$)'; then
+        echo "BLOCKED: Destructive 'git clean' outside project directory. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    fi
+    # git checkout . and git checkout -- .
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+checkout([[:space:]]+--)?[[:space:]]+\.([[:space:]]|$)'; then
+      echo "BLOCKED: Destructive 'git checkout .' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # git reset --hard
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+reset[[:space:]]+--hard'; then
+      echo "BLOCKED: Destructive 'git reset --hard' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # git push --force / -f
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+push[[:space:]]+.*(--force|-f)([[:space:]]|$)'; then
+      echo "BLOCKED: Destructive 'git push --force' outside project directory. Ask user for explicit permission." >&2
       exit 2
     fi
     # Destructive rails/rake subcommands

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -220,35 +220,6 @@ check_single_command() {
     fi
   fi
 
-  # --- Always blocked (dangerous regardless of location) ---
-  # Normalize multiple spaces to single space for pattern matching
-  local CMD_NORMALIZED
-  CMD_NORMALIZED=$(echo "$CMD" | sed 's/[[:space:]]\{1,\}/ /g')
-  local ALWAYS_BLOCKED=(
-    "git push.*--force"
-    "git push.*-f($|[[:space:]])"
-    "git reset --hard"
-    "git checkout \."
-    "git clean.*-f"
-    "drop_table"
-    "drop table"
-    "truncate table"
-    "rails db:drop"
-    "rails db:reset"
-    "rake db:drop"
-    "rake db:reset"
-    "mkfs\."
-    "dd if="
-    "(^|[[:space:]])format($|[[:space:]]).*disk"
-  )
-
-  for pattern in "${ALWAYS_BLOCKED[@]}"; do
-    if echo "$CMD_NORMALIZED" | grep -qiE "$pattern"; then
-      echo "BLOCKED: '$CMD' matches dangerous pattern '$pattern'. This command is always blocked. Ask user for explicit permission." >&2
-      exit 2
-    fi
-  done
-
   # --- xargs with dangerous commands ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])xargs($|[[:space:]])'; then
     # Check if xargs is followed by a dangerous command

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -245,6 +245,26 @@ check_single_command() {
       echo "BLOCKED: Destructive 'git push --force' outside project directory. Ask user for explicit permission." >&2
       exit 2
     fi
+    # git restore . / git restore -- . / git restore --worktree .
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+restore([[:space:]]+(--worktree|--staged|--))*[[:space:]]+\.([[:space:]]|$)'; then
+      echo "BLOCKED: Destructive 'git restore .' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # git stash drop / clear
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+stash[[:space:]]+(drop|clear)'; then
+      echo "BLOCKED: Destructive 'git stash drop/clear' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # git branch -D / --delete --force
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+branch[[:space:]]+(-D|--delete[[:space:]]+--force)'; then
+      echo "BLOCKED: Destructive 'git branch -D' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    # git reflog expire --all or --expire=now
+    if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+reflog[[:space:]]+expire'; then
+      echo "BLOCKED: Destructive 'git reflog expire' outside project directory. Ask user for explicit permission." >&2
+      exit 2
+    fi
     # Destructive rails/rake subcommands
     if echo "$CMD" | grep -qE '(^|[[:space:]])(rails|rake)[[:space:]]+db:(drop|reset)'; then
       echo "BLOCKED: Destructive rails/rake command outside project directory. Ask user for explicit permission." >&2
@@ -443,6 +463,102 @@ check_single_command() {
         exit 2
       fi
     done
+  fi
+
+  # --- install command: like cp, check all non-flag path arguments ---
+  if echo "$CMD" | grep -qE '(^|[[:space:]])install($|[[:space:]])'; then
+    INSTALL_ARGS=$(echo "$CMD" | grep -oE '(^|[[:space:]])install[[:space:]]+.*' | sed 's/^[[:space:]]*install[[:space:]]*//' | tr ' ' '\n' | grep -v '^-')
+    # Skip mode arg (numeric, after -m/--mode), owner arg (after -o), group (after -g)
+    for TARGET in $INSTALL_ARGS; do
+      # Skip pure numeric (mode) or user:group patterns
+      if [[ "$TARGET" =~ ^[0-9]+$ ]] || [[ "$TARGET" =~ ^[a-zA-Z_][a-zA-Z0-9_]*(:[a-zA-Z_][a-zA-Z0-9_]*)?$ ]]; then
+        continue
+      fi
+      TARGET=$(expand_path "$TARGET")
+      if [[ "$TARGET" != /* ]]; then
+        TARGET="$EFFECTIVE_CWD/$TARGET"
+      fi
+      RESOLVED=$(resolve_path "$TARGET")
+      if ! is_inside_project "$RESOLVED"; then
+        echo "BLOCKED: 'install' argument '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    done
+  fi
+
+  # --- rsync command: check all non-flag path arguments ---
+  if echo "$CMD" | grep -qE '(^|[[:space:]])rsync($|[[:space:]])'; then
+    RSYNC_ARGS=$(echo "$CMD" | grep -oE '(^|[[:space:]])rsync[[:space:]]+.*' | sed 's/^[[:space:]]*rsync[[:space:]]*//' | tr ' ' '\n' | grep -v '^-')
+    for TARGET in $RSYNC_ARGS; do
+      # Skip remote paths (user@host:/path or host:/path)
+      if [[ "$TARGET" =~ : ]]; then
+        continue
+      fi
+      TARGET=$(expand_path "$TARGET")
+      if [[ "$TARGET" != /* ]]; then
+        TARGET="$EFFECTIVE_CWD/$TARGET"
+      fi
+      RESOLVED=$(resolve_path "$TARGET")
+      if ! is_inside_project "$RESOLVED"; then
+        echo "BLOCKED: 'rsync' argument '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    done
+  fi
+
+  # --- tar: check -C / --directory=PATH for extraction ---
+  if echo "$CMD" | grep -qE '(^|[[:space:]])tar($|[[:space:]])'; then
+    # -C PATH (separated)
+    tar_dir=$(echo "$CMD" | grep -oE '(^|[[:space:]])-C[[:space:]]+[^ ]+' | sed -E 's/.*-C[[:space:]]+//' || true)
+    if [ -z "$tar_dir" ]; then
+      # --directory=PATH
+      tar_dir=$(echo "$CMD" | grep -oE '\-\-directory=[^ ]+' | sed 's/--directory=//' || true)
+    fi
+    if [ -n "$tar_dir" ]; then
+      tar_dir=$(expand_path "$tar_dir")
+      if [[ "$tar_dir" != /* ]]; then
+        tar_dir="$EFFECTIVE_CWD/$tar_dir"
+      fi
+      local resolved_tar
+      resolved_tar=$(resolve_path "$tar_dir")
+      if ! is_inside_project "$resolved_tar"; then
+        echo "BLOCKED: 'tar -C' targets '$resolved_tar' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    fi
+  fi
+
+  # --- unzip -d PATH / cpio -D PATH ---
+  if echo "$CMD" | grep -qE '(^|[[:space:]])unzip($|[[:space:]])'; then
+    unzip_dir=$(echo "$CMD" | grep -oE '(^|[[:space:]])-d[[:space:]]+[^ ]+' | sed -E 's/.*-d[[:space:]]+//' || true)
+    if [ -n "$unzip_dir" ]; then
+      unzip_dir=$(expand_path "$unzip_dir")
+      if [[ "$unzip_dir" != /* ]]; then
+        unzip_dir="$EFFECTIVE_CWD/$unzip_dir"
+      fi
+      local resolved_unzip
+      resolved_unzip=$(resolve_path "$unzip_dir")
+      if ! is_inside_project "$resolved_unzip"; then
+        echo "BLOCKED: 'unzip -d' targets '$resolved_unzip' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    fi
+  fi
+
+  if echo "$CMD" | grep -qE '(^|[[:space:]])cpio($|[[:space:]])'; then
+    cpio_dir=$(echo "$CMD" | grep -oE '(^|[[:space:]])-D[[:space:]]+[^ ]+' | sed -E 's/.*-D[[:space:]]+//' || true)
+    if [ -n "$cpio_dir" ]; then
+      cpio_dir=$(expand_path "$cpio_dir")
+      if [[ "$cpio_dir" != /* ]]; then
+        cpio_dir="$EFFECTIVE_CWD/$cpio_dir"
+      fi
+      local resolved_cpio
+      resolved_cpio=$(resolve_path "$cpio_dir")
+      if ! is_inside_project "$resolved_cpio"; then
+        echo "BLOCKED: 'cpio -D' targets '$resolved_cpio' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    fi
   fi
 
   # --- tee command: extract file arguments, block if outside project ---

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -81,6 +81,13 @@ resolve_path() {
 # Resolve PROJECT_DIR itself so symlinks (e.g. /var -> /private/var on macOS) match
 PROJECT_DIR=$(resolve_path "$PROJECT_DIR")
 
+# Check if the effective working directory is outside the project
+EFFECTIVE_CWD_RESOLVED=$(resolve_path "$EFFECTIVE_CWD")
+CWD_OUTSIDE_PROJECT=0
+if [[ "$EFFECTIVE_CWD_RESOLVED/" != "$PROJECT_DIR/"* ]]; then
+  CWD_OUTSIDE_PROJECT=1
+fi
+
 # --- Expand ~ and $HOME in a command argument ---
 expand_path() {
   local p="$1"
@@ -188,21 +195,27 @@ check_single_command() {
     return 0
   fi
 
-  # If a previous cd went outside project, block any destructive command
-  if [[ "${_GUARD_CD_OUTSIDE:-0}" == "1" ]]; then
+  # Block destructive commands when running outside the project
+  # (either via cd in a chained command, or via cwd from the hook event)
+  local outside_context=0
+  if [[ "${_GUARD_CD_OUTSIDE:-0}" == "1" || "$CWD_OUTSIDE_PROJECT" == "1" ]]; then
+    outside_context=1
+  fi
+
+  if [[ "$outside_context" == "1" ]]; then
     local destructive_cmds="rm|mv|cp|ln|chmod|chown|tee|find|curl|wget|dd"
     if echo "$CMD" | grep -qE "(^|[[:space:]])($destructive_cmds)($|[[:space:]])"; then
-      echo "BLOCKED: Destructive command after 'cd' outside project directory. Ask user for explicit permission." >&2
+      echo "BLOCKED: Destructive command outside project directory. Ask user for explicit permission." >&2
       exit 2
     fi
     # Destructive git subcommands
     if echo "$CMD" | grep -qE '(^|[[:space:]])git[[:space:]]+(clean|checkout[[:space:]]+\.|reset[[:space:]]+--hard|push[[:space:]]+.*(-f|--force))'; then
-      echo "BLOCKED: Destructive git command after 'cd' outside project directory. Ask user for explicit permission." >&2
+      echo "BLOCKED: Destructive git command outside project directory. Ask user for explicit permission." >&2
       exit 2
     fi
     # Destructive rails/rake subcommands
     if echo "$CMD" | grep -qE '(^|[[:space:]])(rails|rake)[[:space:]]+db:(drop|reset)'; then
-      echo "BLOCKED: Destructive rails/rake command after 'cd' outside project directory. Ask user for explicit permission." >&2
+      echo "BLOCKED: Destructive rails/rake command outside project directory. Ask user for explicit permission." >&2
       exit 2
     fi
   fi

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -188,9 +188,13 @@ check_single_command() {
     fi
     local resolved_cd
     resolved_cd=$(resolve_path "$cd_target")
+    EFFECTIVE_CWD="$resolved_cd"
     if ! is_inside_project "$resolved_cd"; then
-      # cd outside project — flag it so subsequent commands in chain are blocked
       export _GUARD_CD_OUTSIDE=1
+      CWD_OUTSIDE_PROJECT=1
+    else
+      export _GUARD_CD_OUTSIDE=0
+      CWD_OUTSIDE_PROJECT=0
     fi
     return 0
   fi
@@ -203,7 +207,7 @@ check_single_command() {
   fi
 
   if [[ "$outside_context" == "1" ]]; then
-    local destructive_cmds="rm|mv|cp|ln|chmod|chown|tee|find|curl|wget|dd"
+    local destructive_cmds="rm|mv|cp|ln|chmod|chown|tee|find|curl|wget"
     if echo "$CMD" | grep -qE "(^|[[:space:]])($destructive_cmds)($|[[:space:]])"; then
       echo "BLOCKED: Destructive command outside project directory. Ask user for explicit permission." >&2
       exit 2
@@ -483,7 +487,7 @@ check_single_command() {
   # --- dd of= outside project ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])dd($|[[:space:]])'; then
     local dd_output=""
-    dd_output=$(echo "$CMD" | grep -oE 'of=[^ ]+' | sed 's/^of=//')
+    dd_output=$(echo "$CMD" | grep -oE 'of=[^ ]+' | sed 's/^of=//' || true)
     if [ -n "$dd_output" ]; then
       dd_output=$(expand_path "$dd_output")
       if [[ "$dd_output" != /* ]]; then

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Blocks always-dangerous commands everywhere and file operations outside the project directory",
+  "description": "Blocks file operations outside the project directory",
   "hooks": {
     "PreToolUse": [
       {

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -22,10 +22,56 @@ export CLAUDE_PROJECT_DIR="$PROJECT"
 
 run_guard() {
   local cmd="$1"
+  local cwd="${2:-}"
   local json
-  json=$(jq -n --arg c "$cmd" '{"tool_input": {"command": $c}}')
+  if [ -n "$cwd" ]; then
+    json=$(jq -n --arg c "$cmd" --arg d "$cwd" '{"cwd": $d, "tool_input": {"command": $c}}')
+  else
+    json=$(jq -n --arg c "$cmd" '{"tool_input": {"command": $c}}')
+  fi
   echo "$json" | bash "$GUARD" 2>/dev/null
   return $?
+}
+
+run_guard_cwd() {
+  local cmd="$1"
+  local cwd="$2"
+  run_guard "$cmd" "$cwd"
+  return $?
+}
+
+expect_blocked_cwd() {
+  local description="$1"
+  local cmd="$2"
+  local cwd="$3"
+  TOTAL=$((TOTAL + 1))
+  run_guard_cwd "$cmd" "$cwd"
+  local rc=$?
+  if [ "$rc" -eq 2 ]; then
+    echo "PASS: $description"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $description -- expected BLOCKED (exit 2) but got exit $rc"
+    echo "      command: $cmd (cwd: $cwd)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+expect_allowed_cwd() {
+  local description="$1"
+  local cmd="$2"
+  local cwd="$3"
+  TOTAL=$((TOTAL + 1))
+  run_guard_cwd "$cmd" "$cwd"
+  local rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "PASS: $description"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $description -- expected ALLOWED (exit 0) but got exit $rc"
+    echo "      command: $cmd (cwd: $cwd)"
+    FAIL=$((FAIL + 1))
+  fi
 }
 
 expect_blocked() {

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -814,6 +814,10 @@ expect_allowed_cwd "git clean -nfd (dry-run) with cwd=/tmp" \
 expect_allowed_cwd "git clean --dry-run -fd with cwd=/tmp" \
   "git clean --dry-run -fd" "/tmp"
 
+# git clean without -f is a no-op (git refuses) — should not be blocked
+expect_allowed_cwd "git clean (no -f) with cwd=/tmp" \
+  "git clean" "/tmp"
+
 expect_blocked_cwd "git push --force with cwd=/tmp" \
   "git push --force origin main" "/tmp"
 

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -778,6 +778,56 @@ expect_blocked "dd of=~/file" \
 echo ""
 
 # ============================================================
+# 45b. Archive extraction (tar, unzip, cpio)
+# ============================================================
+echo "--- Archive extraction ---"
+
+expect_blocked "tar -C /etc -xf" \
+  "tar -C /etc -xf archive.tar"
+
+expect_blocked "tar --directory=/etc -xf" \
+  "tar --directory=/etc -xf archive.tar"
+
+expect_allowed "tar -C inside project" \
+  "tar -C $PROJECT/extract -xf archive.tar"
+
+expect_blocked "unzip -d /etc" \
+  "unzip -d /etc archive.zip"
+
+expect_allowed "unzip -d inside project" \
+  "unzip -d $PROJECT/extract archive.zip"
+
+expect_blocked "cpio -D /etc" \
+  "cpio -D /etc -i"
+
+echo ""
+
+# ============================================================
+# 45c. install and rsync
+# ============================================================
+echo "--- install and rsync ---"
+
+expect_blocked "install /etc/passwd project" \
+  "install /etc/passwd $PROJECT/stolen"
+
+expect_blocked "install to /etc" \
+  "install $PROJECT/file /etc/somewhere"
+
+expect_allowed "install inside project" \
+  "install -m 644 $PROJECT/a $PROJECT/b"
+
+expect_blocked "rsync /etc/passwd" \
+  "rsync /etc/passwd $PROJECT/"
+
+expect_blocked "rsync to /etc" \
+  "rsync $PROJECT/file /etc/"
+
+expect_allowed "rsync inside project" \
+  "rsync -av $PROJECT/src/ $PROJECT/dst/"
+
+echo ""
+
+# ============================================================
 # 46. cwd from hook event payload
 # ============================================================
 echo "--- cwd from hook event ---"
@@ -826,6 +876,25 @@ expect_blocked_cwd "rails db:drop with cwd=/tmp" \
 
 expect_blocked_cwd "rake db:reset with cwd=/tmp" \
   "rake db:reset" "/tmp"
+
+# More destructive git commands after cd outside project
+expect_blocked_cwd "git restore . with cwd=/tmp" \
+  "git restore ." "/tmp"
+
+expect_blocked_cwd "git restore -- . with cwd=/tmp" \
+  "git restore -- ." "/tmp"
+
+expect_blocked_cwd "git stash drop with cwd=/tmp" \
+  "git stash drop" "/tmp"
+
+expect_blocked_cwd "git stash clear with cwd=/tmp" \
+  "git stash clear" "/tmp"
+
+expect_blocked_cwd "git branch -D with cwd=/tmp" \
+  "git branch -D feature" "/tmp"
+
+expect_blocked_cwd "git reflog expire with cwd=/tmp" \
+  "git reflog expire --expire=now --all" "/tmp"
 
 # Safe git with cwd outside project — allowed
 expect_allowed_cwd "git status with cwd=/tmp (safe)" \

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -795,3 +795,28 @@ expect_allowed_cwd "mv file with cwd=project" \
   "mv a.txt b.txt" "$PROJECT"
 
 echo ""
+
+# ============================================================
+# 47. Previously always-blocked commands are now allowed inside project
+# ============================================================
+echo "--- Removed global blocks (regression guard) ---"
+
+expect_allowed "git push --force (inside project)" \
+  "git push --force origin main"
+
+expect_allowed "git reset --hard (inside project)" \
+  "git reset --hard HEAD~1"
+
+expect_allowed "git checkout . (inside project)" \
+  "git checkout ."
+
+expect_allowed "git clean -fd (inside project)" \
+  "git clean -fd"
+
+expect_allowed "rails db:drop (inside project)" \
+  "rails db:drop"
+
+expect_allowed "rake db:reset (inside project)" \
+  "rake db:reset"
+
+echo ""

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -589,6 +589,19 @@ expect_blocked "cd /tmp && rails db:drop" \
 expect_blocked "cd /tmp && rake db:reset" \
   "cd /tmp && rake db:reset"
 
+# safe git/rails/rake after cd outside — allowed
+expect_allowed "cd /tmp && git status (safe)" \
+  "cd /tmp && git status"
+
+expect_allowed "cd /tmp && git log (safe)" \
+  "cd /tmp && git log"
+
+expect_allowed "cd /tmp && rails routes (safe)" \
+  "cd /tmp && rails routes"
+
+expect_allowed "cd /tmp && rake -T (safe)" \
+  "cd /tmp && rake -T"
+
 # git inside project — allowed
 expect_allowed "cd to project && git status" \
   "cd $PROJECT && git status"
@@ -747,5 +760,38 @@ expect_blocked "mv -t /tmp" \
   "mv -t /tmp $PROJECT/file.txt"
 
 echo ""
+
+# ============================================================
+# 45. dd of= boundary check
+# ============================================================
+echo "--- dd of= boundary check ---"
+
+expect_blocked "dd of=/etc/file" \
+  "dd if=/dev/zero of=/etc/file bs=1M count=1"
+
+expect_allowed "dd of= inside project" \
+  "dd if=/dev/zero of=$PROJECT/file.bin bs=1M count=1"
+
+expect_blocked "dd of=~/file" \
+  "dd if=/dev/zero of=~/file bs=1M"
+
+echo ""
+
+# ============================================================
+# 46. cwd from hook event payload
+# ============================================================
+echo "--- cwd from hook event ---"
+
+expect_blocked_cwd "rm relative file with cwd=/tmp" \
+  "rm relative.txt" "/tmp"
+
+expect_allowed_cwd "rm relative file with cwd=project" \
+  "rm relative.txt" "$PROJECT"
+
+expect_blocked_cwd "mv file with cwd=/tmp" \
+  "mv a.txt b.txt" "/tmp"
+
+expect_allowed_cwd "mv file with cwd=project" \
+  "mv a.txt b.txt" "$PROJECT"
 
 echo ""

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -9,56 +9,7 @@ echo "========================================"
 echo ""
 
 # ============================================================
-# 1. Always-blocked patterns
-# ============================================================
-echo "--- Always-blocked patterns ---"
-
-expect_blocked "git push --force" \
-  "git push --force origin main"
-
-expect_blocked "git push -f (with space after)" \
-  "git push -f origin main"
-
-expect_blocked "git push -f (end of command)" \
-  "git push origin main -f"
-
-expect_blocked "git reset --hard" \
-  "git reset --hard HEAD~1"
-
-expect_blocked "git checkout ." \
-  "git checkout ."
-
-expect_blocked "git clean -f" \
-  "git clean -fd"
-
-expect_blocked "drop table (SQL)" \
-  "echo 'DROP TABLE users;'"
-
-expect_blocked "truncate table (SQL)" \
-  "echo 'TRUNCATE TABLE users;'"
-
-expect_blocked "rails db:drop" \
-  "rails db:drop"
-
-expect_blocked "rails db:reset" \
-  "rails db:reset"
-
-expect_blocked "rake db:drop" \
-  "rake db:drop"
-
-expect_blocked "rake db:reset" \
-  "rake db:reset"
-
-expect_blocked "mkfs" \
-  "mkfs.ext4 /dev/sda1"
-
-expect_blocked "dd if=" \
-  "dd if=/dev/zero of=/dev/sda"
-
-echo ""
-
-# ============================================================
-# 2. rm inside project (should PASS)
+# 1. rm inside project (should PASS)
 # ============================================================
 echo "--- rm inside project ---"
 
@@ -776,16 +727,5 @@ expect_blocked "mv -t /tmp" \
   "mv -t /tmp $PROJECT/file.txt"
 
 echo ""
-
-# ============================================================
-# 45. ALWAYS_BLOCKED spacing variants
-# ============================================================
-echo "--- Always-blocked spacing variants ---"
-
-expect_blocked "git  reset  --hard (extra spaces)" \
-  "git  reset  --hard"
-
-expect_blocked "git push  --force (extra space)" \
-  "git push  --force"
 
 echo ""

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -820,6 +820,21 @@ expect_allowed_cwd "git status with cwd=/tmp (safe)" \
 expect_allowed_cwd "git log with cwd=/tmp (safe)" \
   "git log" "/tmp"
 
+# cd back into project from outside cwd — should allow
+expect_allowed_cwd "cd to project && rm file (cwd=/tmp)" \
+  "cd $PROJECT && rm file.txt" "/tmp"
+
+expect_allowed_cwd "cd to project && git clean (cwd=/tmp)" \
+  "cd $PROJECT && git clean -fd" "/tmp"
+
+# dd with cwd outside — of= inside project should be allowed
+expect_allowed_cwd "dd of= inside project (cwd=/tmp)" \
+  "dd if=/dev/zero of=$PROJECT/file.bin bs=1M count=1" "/tmp"
+
+# dd with cwd outside — of= outside project should be blocked
+expect_blocked_cwd "dd of=/etc/file (cwd=/tmp)" \
+  "dd if=/dev/zero of=/etc/file bs=1M count=1" "/tmp"
+
 echo ""
 
 # ============================================================

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -794,6 +794,32 @@ expect_blocked_cwd "mv file with cwd=/tmp" \
 expect_allowed_cwd "mv file with cwd=project" \
   "mv a.txt b.txt" "$PROJECT"
 
+# Destructive git/rails/rake with cwd outside project
+expect_blocked_cwd "git clean with cwd=/tmp" \
+  "git clean -fd" "/tmp"
+
+expect_blocked_cwd "git reset --hard with cwd=/tmp" \
+  "git reset --hard HEAD~1" "/tmp"
+
+expect_blocked_cwd "git checkout . with cwd=/tmp" \
+  "git checkout ." "/tmp"
+
+expect_blocked_cwd "git push --force with cwd=/tmp" \
+  "git push --force origin main" "/tmp"
+
+expect_blocked_cwd "rails db:drop with cwd=/tmp" \
+  "rails db:drop" "/tmp"
+
+expect_blocked_cwd "rake db:reset with cwd=/tmp" \
+  "rake db:reset" "/tmp"
+
+# Safe git with cwd outside project — allowed
+expect_allowed_cwd "git status with cwd=/tmp (safe)" \
+  "git status" "/tmp"
+
+expect_allowed_cwd "git log with cwd=/tmp (safe)" \
+  "git log" "/tmp"
+
 echo ""
 
 # ============================================================

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -804,6 +804,16 @@ expect_blocked_cwd "git reset --hard with cwd=/tmp" \
 expect_blocked_cwd "git checkout . with cwd=/tmp" \
   "git checkout ." "/tmp"
 
+expect_blocked_cwd "git checkout -- . with cwd=/tmp" \
+  "git checkout -- ." "/tmp"
+
+# git clean dry-run variants — safe, allowed
+expect_allowed_cwd "git clean -nfd (dry-run) with cwd=/tmp" \
+  "git clean -nfd" "/tmp"
+
+expect_allowed_cwd "git clean --dry-run -fd with cwd=/tmp" \
+  "git clean --dry-run -fd" "/tmp"
+
 expect_blocked_cwd "git push --force with cwd=/tmp" \
   "git push --force origin main" "/tmp"
 

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -573,6 +573,26 @@ expect_blocked "cd /tmp && rm -rf something" \
 expect_allowed "cd to project subdir && rm file" \
   "cd $PROJECT/subdir && rm file.txt"
 
+# git/rails/rake after cd outside project
+expect_blocked "cd /tmp && git clean -fd" \
+  "cd /tmp && git clean -fd"
+
+expect_blocked "cd /tmp && git checkout ." \
+  "cd /tmp && git checkout ."
+
+expect_blocked "cd /tmp && git reset --hard" \
+  "cd /tmp && git reset --hard HEAD~1"
+
+expect_blocked "cd /tmp && rails db:drop" \
+  "cd /tmp && rails db:drop"
+
+expect_blocked "cd /tmp && rake db:reset" \
+  "cd /tmp && rake db:reset"
+
+# git inside project — allowed
+expect_allowed "cd to project && git status" \
+  "cd $PROJECT && git status"
+
 echo ""
 
 # ============================================================


### PR DESCRIPTION
## Summary
- Remove 9 commands that were always blocked regardless of location (git push --force, DROP TABLE, mkfs, dd, etc.)
- These don't fit the "project boundary" concept — they have no path to check
- Nested shell/eval/xargs blocks remain because they prevent boundary check bypass
- Belongs in a separate plugin if needed

## Test plan
- [x] 170 tests pass locally (macOS)
- [ ] CI passes on Ubuntu and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)