### PR TITLE
Fix #6: option extractors bypass boundary check on quoted paths with spaces

### DIFF
--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -600,22 +600,41 @@ check_single_command() {
     done < <(tokenize_args "$rsync_raw")
   fi
 
-  # --- tar: check -C / --directory=PATH for extraction ---
+  # --- tar: check every -C / --directory=PATH for extraction ---
+  # tar allows multiple -C switches and the *last* one wins, so we must
+  # validate every occurrence — not just the first.
   if echo "$CMD" | grep -qE '(^|[[:space:]])tar($|[[:space:]])'; then
-    local tar_dir
-    tar_dir=$(extract_option_value "-C" "--directory" || true)
-    if [ -n "$tar_dir" ]; then
-      tar_dir=$(expand_path "$tar_dir")
-      if [[ "$tar_dir" != /* ]]; then
-        tar_dir="$EFFECTIVE_CWD/$tar_dir"
+    local ti=0 tn=${#CMD_TOKENS[@]}
+    while [ $ti -lt $tn ]; do
+      local ttok="${CMD_TOKENS[$ti]}"
+      local tar_dir=""
+      if [ "$ttok" = "-C" ] || [ "$ttok" = "--directory" ]; then
+        if [ $((ti + 1)) -lt $tn ]; then
+          tar_dir="${CMD_TOKENS[$((ti + 1))]}"
+          ti=$((ti + 2))
+        else
+          ti=$((ti + 1))
+        fi
+      elif [[ "$ttok" == "--directory="* ]]; then
+        tar_dir="${ttok#--directory=}"
+        ti=$((ti + 1))
+      else
+        ti=$((ti + 1))
+        continue
       fi
-      local resolved_tar
-      resolved_tar=$(resolve_path "$tar_dir")
-      if ! is_inside_project "$resolved_tar"; then
-        echo "BLOCKED: 'tar -C' targets '$resolved_tar' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
+      if [ -n "$tar_dir" ]; then
+        tar_dir=$(expand_path "$tar_dir")
+        if [[ "$tar_dir" != /* ]]; then
+          tar_dir="$EFFECTIVE_CWD/$tar_dir"
+        fi
+        local resolved_tar
+        resolved_tar=$(resolve_path "$tar_dir")
+        if ! is_inside_project "$resolved_tar"; then
+          echo "BLOCKED: 'tar -C' targets '$resolved_tar' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+          exit 2
+        fi
       fi
-    fi
+    done
   fi
 
   # --- unzip -d PATH ---
@@ -711,57 +730,74 @@ check_single_command() {
   fi
 
   # --- dd of= outside project ---
+  # dd accepts repeated key=value operands and the last one wins, so we must
+  # validate every of= occurrence — not just the first.
   if echo "$CMD" | grep -qE '(^|[[:space:]])dd($|[[:space:]])'; then
-    local dd_output=""
-    # dd uses key=value syntax, not standard long options — walk tokens directly
     for tok in "${CMD_TOKENS[@]}"; do
       if [[ "$tok" == of=* ]]; then
-        dd_output="${tok#of=}"
-        break
+        local dd_output="${tok#of=}"
+        if [ -n "$dd_output" ]; then
+          dd_output=$(expand_path "$dd_output")
+          if [[ "$dd_output" != /* ]]; then
+            dd_output="$EFFECTIVE_CWD/$dd_output"
+          fi
+          local resolved_dd
+          resolved_dd=$(resolve_path "$dd_output")
+          if ! is_inside_project "$resolved_dd"; then
+            echo "BLOCKED: 'dd' output '$resolved_dd' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+            exit 2
+          fi
+        fi
       fi
     done
-    if [ -n "$dd_output" ]; then
-      dd_output=$(expand_path "$dd_output")
-      if [[ "$dd_output" != /* ]]; then
-        dd_output="$EFFECTIVE_CWD/$dd_output"
-      fi
-      local resolved_dd
-      resolved_dd=$(resolve_path "$dd_output")
-      if ! is_inside_project "$resolved_dd"; then
-        echo "BLOCKED: 'dd' output '$resolved_dd' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
-      fi
-    fi
   fi
 
-  # --- Writing to files outside project via redirection (> and >>) ---
-  # Walk tokens to find redirect targets. Handles: > file, >> file, >file, >>file
+  # --- Writing to files outside project via redirection ---
+  # Walk tokens to find redirect targets. Handles:
+  #   > file, >> file, >file, >>file
+  #   1> file, 2> file, 1>file, 2>>file
+  #   &> file, &>file, &>>file
+  # Skips fd-to-fd redirects like 2>&1.
   local ri=0 rn=${#CMD_TOKENS[@]}
   while [ $ri -lt $rn ]; do
     local rtok="${CMD_TOKENS[$ri]}"
     local REDIR_TARGET=""
-    case "$rtok" in
-      '>'|'>>')
+    local rest=""
+    local matched=0
+
+    if [[ "$rtok" =~ ^[0-9]+(\>\>?)(.*)$ ]]; then
+      rest="${BASH_REMATCH[2]}"
+      matched=1
+    elif [[ "$rtok" =~ ^\&(\>\>?)(.*)$ ]]; then
+      rest="${BASH_REMATCH[2]}"
+      matched=1
+    elif [[ "$rtok" =~ ^(\>\>?)(.*)$ ]]; then
+      rest="${BASH_REMATCH[2]}"
+      matched=1
+    fi
+
+    if [ "$matched" -eq 1 ]; then
+      if [ -z "$rest" ]; then
+        # Separated form: target is next token
         if [ $((ri + 1)) -lt $rn ]; then
           REDIR_TARGET="${CMD_TOKENS[$((ri + 1))]}"
           ri=$((ri + 2))
         else
           ri=$((ri + 1))
         fi
-        ;;
-      '>>'*)
-        REDIR_TARGET="${rtok#>>}"
+      elif [[ "$rest" == \&* ]]; then
+        # fd-to-fd redirect like 2>&1, no file target
         ri=$((ri + 1))
-        ;;
-      '>'*)
-        REDIR_TARGET="${rtok#>}"
+      else
+        # Attached form: rest is the file
+        REDIR_TARGET="$rest"
         ri=$((ri + 1))
-        ;;
-      *)
-        ri=$((ri + 1))
-        continue
-        ;;
-    esac
+      fi
+    else
+      ri=$((ri + 1))
+      continue
+    fi
+
     if [ -n "$REDIR_TARGET" ]; then
       REDIR_TARGET=$(expand_path "$REDIR_TARGET")
       if [[ "$REDIR_TARGET" != /* ]]; then

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -153,30 +153,40 @@ tokenize_args() {
 #   short: e.g. "-o", or "" to skip
 #   long:  e.g. "--output", or "" to skip
 # Supports: "-o value", "--output value", "--output=value"
+# If an option appears multiple times, returns the LAST match — this matches
+# the "last-wins" semantics of curl/wget/cp/mv/tar and prevents a bypass where
+# an attacker places an in-project value first and an outside value second
+# (e.g. `curl -o $PROJECT/ok -o /etc/passwd`).
 # Echoes the value (quotes preserved — caller must expand_path).
 # Returns 0 if found, 1 otherwise.
 extract_option_value() {
   local short="$1"
   local long="$2"
   local i=0 n=${#CMD_TOKENS[@]}
+  local found=1
+  local value=""
   while [ $i -lt $n ]; do
     local tok="${CMD_TOKENS[$i]}"
     if [ -n "$short" ] && [ "$tok" = "$short" ] && [ $((i + 1)) -lt $n ]; then
-      echo "${CMD_TOKENS[$((i + 1))]}"
-      return 0
+      value="${CMD_TOKENS[$((i + 1))]}"
+      found=0
     fi
     if [ -n "$long" ]; then
       if [ "$tok" = "$long" ] && [ $((i + 1)) -lt $n ]; then
-        echo "${CMD_TOKENS[$((i + 1))]}"
-        return 0
+        value="${CMD_TOKENS[$((i + 1))]}"
+        found=0
       fi
       if [[ "$tok" == "${long}="* ]]; then
-        echo "${tok#${long}=}"
-        return 0
+        value="${tok#${long}=}"
+        found=0
       fi
     fi
     i=$((i + 1))
   done
+  if [ $found -eq 0 ]; then
+    echo "$value"
+    return 0
+  fi
   return 1
 }
 

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -148,6 +148,38 @@ tokenize_args() {
   done
 }
 
+# --- Extract an option value from CMD_TOKENS ---
+# Usage: extract_option_value <short> <long>
+#   short: e.g. "-o", or "" to skip
+#   long:  e.g. "--output", or "" to skip
+# Supports: "-o value", "--output value", "--output=value"
+# Echoes the value (quotes preserved — caller must expand_path).
+# Returns 0 if found, 1 otherwise.
+extract_option_value() {
+  local short="$1"
+  local long="$2"
+  local i=0 n=${#CMD_TOKENS[@]}
+  while [ $i -lt $n ]; do
+    local tok="${CMD_TOKENS[$i]}"
+    if [ -n "$short" ] && [ "$tok" = "$short" ] && [ $((i + 1)) -lt $n ]; then
+      echo "${CMD_TOKENS[$((i + 1))]}"
+      return 0
+    fi
+    if [ -n "$long" ]; then
+      if [ "$tok" = "$long" ] && [ $((i + 1)) -lt $n ]; then
+        echo "${CMD_TOKENS[$((i + 1))]}"
+        return 0
+      fi
+      if [[ "$tok" == "${long}="* ]]; then
+        echo "${tok#${long}=}"
+        return 0
+      fi
+    fi
+    i=$((i + 1))
+  done
+  return 1
+}
+
 # --- Check if a resolved path is inside the project directory ---
 is_inside_project() {
   local resolved="$1"
@@ -211,6 +243,13 @@ check_single_command() {
     CMD="${CMD#sudo }"
     CMD="$(echo "$CMD" | sed 's/^[[:space:]]*//')"
   fi
+
+  # --- Tokenize the command once (quote-aware) for option/redirect parsing ---
+  local -a CMD_TOKENS=()
+  while IFS= read -r tok; do
+    [[ -z "$tok" ]] && continue
+    CMD_TOKENS+=("$tok")
+  done < <(tokenize_args "$CMD")
 
   # --- Block cd outside project followed by destructive commands ---
   if [[ "$CMD" =~ ^cd($|[[:space:]]) ]]; then
@@ -432,9 +471,9 @@ check_single_command() {
 
   # --- Moving files outside project ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])mv($|[[:space:]])'; then
-    # Check --target-directory=PATH
+    # Check -t / --target-directory
     local mv_target_dir
-    mv_target_dir=$(echo "$CMD" | grep -oE '\-\-target-directory=[^ ]+' | sed 's/--target-directory=//' || true)
+    mv_target_dir=$(extract_option_value "-t" "--target-directory" || true)
     if [ -n "$mv_target_dir" ]; then
       mv_target_dir=$(expand_path "$mv_target_dir")
       [[ "$mv_target_dir" != /* ]] && mv_target_dir="$EFFECTIVE_CWD/$mv_target_dir"
@@ -465,9 +504,9 @@ check_single_command() {
 
   # --- cp command: check all non-flag arguments ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])cp($|[[:space:]])'; then
-    # Check --target-directory=PATH
+    # Check -t / --target-directory
     local cp_target_dir
-    cp_target_dir=$(echo "$CMD" | grep -oE '\-\-target-directory=[^ ]+' | sed 's/--target-directory=//' || true)
+    cp_target_dir=$(extract_option_value "-t" "--target-directory" || true)
     if [ -n "$cp_target_dir" ]; then
       cp_target_dir=$(expand_path "$cp_target_dir")
       [[ "$cp_target_dir" != /* ]] && cp_target_dir="$EFFECTIVE_CWD/$cp_target_dir"
@@ -563,12 +602,8 @@ check_single_command() {
 
   # --- tar: check -C / --directory=PATH for extraction ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])tar($|[[:space:]])'; then
-    # -C PATH (separated)
-    tar_dir=$(echo "$CMD" | grep -oE '(^|[[:space:]])-C[[:space:]]+[^ ]+' | sed -E 's/.*-C[[:space:]]+//' || true)
-    if [ -z "$tar_dir" ]; then
-      # --directory=PATH
-      tar_dir=$(echo "$CMD" | grep -oE '\-\-directory=[^ ]+' | sed 's/--directory=//' || true)
-    fi
+    local tar_dir
+    tar_dir=$(extract_option_value "-C" "--directory" || true)
     if [ -n "$tar_dir" ]; then
       tar_dir=$(expand_path "$tar_dir")
       if [[ "$tar_dir" != /* ]]; then
@@ -583,9 +618,10 @@ check_single_command() {
     fi
   fi
 
-  # --- unzip -d PATH / cpio -D PATH ---
+  # --- unzip -d PATH ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])unzip($|[[:space:]])'; then
-    unzip_dir=$(echo "$CMD" | grep -oE '(^|[[:space:]])-d[[:space:]]+[^ ]+' | sed -E 's/.*-d[[:space:]]+//' || true)
+    local unzip_dir
+    unzip_dir=$(extract_option_value "-d" "" || true)
     if [ -n "$unzip_dir" ]; then
       unzip_dir=$(expand_path "$unzip_dir")
       if [[ "$unzip_dir" != /* ]]; then
@@ -600,8 +636,10 @@ check_single_command() {
     fi
   fi
 
+  # --- cpio -D PATH ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])cpio($|[[:space:]])'; then
-    cpio_dir=$(echo "$CMD" | grep -oE '(^|[[:space:]])-D[[:space:]]+[^ ]+' | sed -E 's/.*-D[[:space:]]+//' || true)
+    local cpio_dir
+    cpio_dir=$(extract_option_value "-D" "" || true)
     if [ -n "$cpio_dir" ]; then
       cpio_dir=$(expand_path "$cpio_dir")
       if [[ "$cpio_dir" != /* ]]; then
@@ -639,14 +677,7 @@ check_single_command() {
   # --- curl -o / curl --output outside project ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])curl($|[[:space:]])'; then
     local curl_output=""
-    # Match -o <file> or --output <file> or --output=<file>
-    if echo "$CMD" | grep -qE '(^|[[:space:]])-o[[:space:]]'; then
-      curl_output=$(echo "$CMD" | sed -E 's/.*[[:space:]]-o[[:space:]]+([^ ]+).*/\1/')
-    elif echo "$CMD" | grep -qE '(^|[[:space:]])--output[[:space:]]'; then
-      curl_output=$(echo "$CMD" | sed -E 's/.*--output[[:space:]]+([^ ]+).*/\1/')
-    elif echo "$CMD" | grep -qE '(^|[[:space:]])--output='; then
-      curl_output=$(echo "$CMD" | sed -E 's/.*--output=([^ ]+).*/\1/')
-    fi
+    curl_output=$(extract_option_value "-o" "--output" || true)
     if [ -n "$curl_output" ]; then
       curl_output=$(expand_path "$curl_output")
       if [[ "$curl_output" != /* ]]; then
@@ -664,13 +695,7 @@ check_single_command() {
   # --- wget -O / wget --output-document outside project ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])wget($|[[:space:]])'; then
     local wget_output=""
-    if echo "$CMD" | grep -qE '(^|[[:space:]])-O[[:space:]]'; then
-      wget_output=$(echo "$CMD" | sed -E 's/.*[[:space:]]-O[[:space:]]+([^ ]+).*/\1/')
-    elif echo "$CMD" | grep -qE '(^|[[:space:]])--output-document[[:space:]]'; then
-      wget_output=$(echo "$CMD" | sed -E 's/.*--output-document[[:space:]]+([^ ]+).*/\1/')
-    elif echo "$CMD" | grep -qE '(^|[[:space:]])--output-document='; then
-      wget_output=$(echo "$CMD" | sed -E 's/.*--output-document=([^ ]+).*/\1/')
-    fi
+    wget_output=$(extract_option_value "-O" "--output-document" || true)
     if [ -n "$wget_output" ]; then
       wget_output=$(expand_path "$wget_output")
       if [[ "$wget_output" != /* ]]; then
@@ -688,7 +713,13 @@ check_single_command() {
   # --- dd of= outside project ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])dd($|[[:space:]])'; then
     local dd_output=""
-    dd_output=$(echo "$CMD" | grep -oE 'of=[^ ]+' | sed 's/^of=//' || true)
+    # dd uses key=value syntax, not standard long options — walk tokens directly
+    for tok in "${CMD_TOKENS[@]}"; do
+      if [[ "$tok" == of=* ]]; then
+        dd_output="${tok#of=}"
+        break
+      fi
+    done
     if [ -n "$dd_output" ]; then
       dd_output=$(expand_path "$dd_output")
       if [[ "$dd_output" != /* ]]; then
@@ -704,22 +735,46 @@ check_single_command() {
   fi
 
   # --- Writing to files outside project via redirection (> and >>) ---
-  if echo "$CMD" | grep -qE '>{1,2}[[:space:]]*/|>{1,2}[[:space:]]*~|>{1,2}[[:space:]]*\$HOME|>{1,2}[[:space:]]*"[/~]|>{1,2}[[:space:]]*'"'"'[/~]|>{1,2}[[:space:]]*\.\.'; then
-    # Extract redirect targets for both > and >>
-    REDIR_TARGET=$(echo "$CMD" | grep -oE '>{1,2}[[:space:]]*[^ ]+' | sed 's/^>*[[:space:]]*//')
+  # Walk tokens to find redirect targets. Handles: > file, >> file, >file, >>file
+  local ri=0 rn=${#CMD_TOKENS[@]}
+  while [ $ri -lt $rn ]; do
+    local rtok="${CMD_TOKENS[$ri]}"
+    local REDIR_TARGET=""
+    case "$rtok" in
+      '>'|'>>')
+        if [ $((ri + 1)) -lt $rn ]; then
+          REDIR_TARGET="${CMD_TOKENS[$((ri + 1))]}"
+          ri=$((ri + 2))
+        else
+          ri=$((ri + 1))
+        fi
+        ;;
+      '>>'*)
+        REDIR_TARGET="${rtok#>>}"
+        ri=$((ri + 1))
+        ;;
+      '>'*)
+        REDIR_TARGET="${rtok#>}"
+        ri=$((ri + 1))
+        ;;
+      *)
+        ri=$((ri + 1))
+        continue
+        ;;
+    esac
     if [ -n "$REDIR_TARGET" ]; then
       REDIR_TARGET=$(expand_path "$REDIR_TARGET")
       if [[ "$REDIR_TARGET" != /* ]]; then
         REDIR_TARGET="$EFFECTIVE_CWD/$REDIR_TARGET"
       fi
-      RESOLVED=$(resolve_path "$REDIR_TARGET")
-
-      if ! is_inside_project "$RESOLVED"; then
-        echo "BLOCKED: Redirect target '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+      local resolved_redir
+      resolved_redir=$(resolve_path "$REDIR_TARGET")
+      if ! is_inside_project "$resolved_redir"; then
+        echo "BLOCKED: Redirect target '$resolved_redir' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
     fi
-  fi
+  done
 
   # --- Chmod/chown outside project ---
   for CMD_NAME in chmod chown; do

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -88,6 +88,21 @@ if [[ "$EFFECTIVE_CWD_RESOLVED/" != "$PROJECT_DIR/"* ]]; then
   CWD_OUTSIDE_PROJECT=1
 fi
 
+# --- Strip one layer of surrounding quotes (single or double) ---
+# Used before matching option flags like `-o` / `--output` against tokens,
+# since tokenize_args preserves quotes: `curl "-o" file` → token `"-o"`.
+strip_quotes() {
+  local p="$1"
+  if [[ "$p" == \"*\" ]]; then
+    p="${p#\"}"
+    p="${p%\"}"
+  elif [[ "$p" == \'*\' ]]; then
+    p="${p#\'}"
+    p="${p%\'}"
+  fi
+  echo "$p"
+}
+
 # --- Expand ~ and $HOME in a command argument ---
 expand_path() {
   local p="$1"
@@ -166,7 +181,10 @@ extract_option_value() {
   local found=1
   local value=""
   while [ $i -lt $n ]; do
-    local tok="${CMD_TOKENS[$i]}"
+    local raw_tok="${CMD_TOKENS[$i]}"
+    # Strip surrounding quotes before matching so `curl "-o" file` works
+    local tok
+    tok=$(strip_quotes "$raw_tok")
     if [ -n "$short" ] && [ "$tok" = "$short" ] && [ $((i + 1)) -lt $n ]; then
       value="${CMD_TOKENS[$((i + 1))]}"
       found=0
@@ -616,7 +634,8 @@ check_single_command() {
   if echo "$CMD" | grep -qE '(^|[[:space:]])tar($|[[:space:]])'; then
     local ti=0 tn=${#CMD_TOKENS[@]}
     while [ $ti -lt $tn ]; do
-      local ttok="${CMD_TOKENS[$ti]}"
+      local ttok
+      ttok=$(strip_quotes "${CMD_TOKENS[$ti]}")
       local tar_dir=""
       if [ "$ttok" = "-C" ] || [ "$ttok" = "--directory" ]; then
         if [ $((ti + 1)) -lt $tn ]; then
@@ -743,7 +762,9 @@ check_single_command() {
   # dd accepts repeated key=value operands and the last one wins, so we must
   # validate every of= occurrence — not just the first.
   if echo "$CMD" | grep -qE '(^|[[:space:]])dd($|[[:space:]])'; then
-    for tok in "${CMD_TOKENS[@]}"; do
+    for raw_tok in "${CMD_TOKENS[@]}"; do
+      local tok
+      tok=$(strip_quotes "$raw_tok")
       if [[ "$tok" == of=* ]]; then
         local dd_output="${tok#of=}"
         if [ -n "$dd_output" ]; then

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -163,51 +163,44 @@ tokenize_args() {
   done
 }
 
-# --- Extract an option value from CMD_TOKENS ---
-# Usage: extract_option_value <short> <long>
+# --- Extract all option values from CMD_TOKENS ---
+# Usage: extract_option_values <short> <long>
 #   short: e.g. "-o", or "" to skip
 #   long:  e.g. "--output", or "" to skip
 # Supports: "-o value", "--output value", "--output=value".
 # Option flags are matched after stripping surrounding quotes so that
-# `curl "-o" /etc/passwd` also matches. If an option appears multiple times,
-# returns the LAST match — this matches the "last-wins" semantics of
-# curl/wget/cp/mv/tar and prevents a bypass where an attacker places an
-# in-project value first and an outside value second
-# (e.g. `curl -o $PROJECT/ok -o /etc/passwd`).
-# Echoes the value (possibly with quotes — caller must expand_path).
-# Returns 0 if found, 1 otherwise.
-extract_option_value() {
+# `curl "-o" /etc/passwd` also matches.
+# Returns EVERY occurrence (one per line) so callers can validate each one.
+# This is fail-closed and handles both "last-wins" tools (tar, cp/mv)
+# and positional tools (curl -o applies to each URL) — if any single
+# occurrence is outside the project boundary, we block.
+# Returns 0 if at least one found, 1 otherwise.
+extract_option_values() {
   local short="$1"
   local long="$2"
   local i=0 n=${#CMD_TOKENS[@]}
   local found=1
-  local value=""
   while [ $i -lt $n ]; do
     local raw_tok="${CMD_TOKENS[$i]}"
-    # Strip surrounding quotes before matching so `curl "-o" file` works
     local tok
     tok=$(strip_quotes "$raw_tok")
     if [ -n "$short" ] && [ "$tok" = "$short" ] && [ $((i + 1)) -lt $n ]; then
-      value="${CMD_TOKENS[$((i + 1))]}"
+      printf '%s\n' "${CMD_TOKENS[$((i + 1))]}"
       found=0
     fi
     if [ -n "$long" ]; then
       if [ "$tok" = "$long" ] && [ $((i + 1)) -lt $n ]; then
-        value="${CMD_TOKENS[$((i + 1))]}"
+        printf '%s\n' "${CMD_TOKENS[$((i + 1))]}"
         found=0
       fi
       if [[ "$tok" == "${long}="* ]]; then
-        value="${tok#${long}=}"
+        printf '%s\n' "${tok#${long}=}"
         found=0
       fi
     fi
     i=$((i + 1))
   done
-  if [ $found -eq 0 ]; then
-    echo "$value"
-    return 0
-  fi
-  return 1
+  return $found
 }
 
 # --- Check if a resolved path is inside the project directory ---
@@ -502,9 +495,8 @@ check_single_command() {
   # --- Moving files outside project ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])mv($|[[:space:]])'; then
     # Check -t / --target-directory
-    local mv_target_dir
-    mv_target_dir=$(extract_option_value "-t" "--target-directory" || true)
-    if [ -n "$mv_target_dir" ]; then
+    while IFS= read -r mv_target_dir; do
+      [ -z "$mv_target_dir" ] && continue
       mv_target_dir=$(expand_path "$mv_target_dir")
       [[ "$mv_target_dir" != /* ]] && mv_target_dir="$EFFECTIVE_CWD/$mv_target_dir"
       local resolved_mv_td
@@ -513,7 +505,7 @@ check_single_command() {
         echo "BLOCKED: 'mv --target-directory' targets '$resolved_mv_td' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
-    fi
+    done < <(extract_option_values "-t" "--target-directory" || true)
     local mv_raw
     mv_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])mv[[:space:]]+.*' | sed 's/^[[:space:]]*mv[[:space:]]*//')
 
@@ -535,9 +527,8 @@ check_single_command() {
   # --- cp command: check all non-flag arguments ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])cp($|[[:space:]])'; then
     # Check -t / --target-directory
-    local cp_target_dir
-    cp_target_dir=$(extract_option_value "-t" "--target-directory" || true)
-    if [ -n "$cp_target_dir" ]; then
+    while IFS= read -r cp_target_dir; do
+      [ -z "$cp_target_dir" ] && continue
       cp_target_dir=$(expand_path "$cp_target_dir")
       [[ "$cp_target_dir" != /* ]] && cp_target_dir="$EFFECTIVE_CWD/$cp_target_dir"
       local resolved_cp_td
@@ -546,7 +537,7 @@ check_single_command() {
         echo "BLOCKED: 'cp --target-directory' targets '$resolved_cp_td' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
-    fi
+    done < <(extract_option_values "-t" "--target-directory" || true)
     local cp_raw
     cp_raw=$(echo "$CMD" | grep -oE '(^|[[:space:]])cp[[:space:]]+.*' | sed 's/^[[:space:]]*cp[[:space:]]*//')
 
@@ -670,9 +661,8 @@ check_single_command() {
 
   # --- unzip -d PATH ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])unzip($|[[:space:]])'; then
-    local unzip_dir
-    unzip_dir=$(extract_option_value "-d" "" || true)
-    if [ -n "$unzip_dir" ]; then
+    while IFS= read -r unzip_dir; do
+      [ -z "$unzip_dir" ] && continue
       unzip_dir=$(expand_path "$unzip_dir")
       if [[ "$unzip_dir" != /* ]]; then
         unzip_dir="$EFFECTIVE_CWD/$unzip_dir"
@@ -683,14 +673,13 @@ check_single_command() {
         echo "BLOCKED: 'unzip -d' targets '$resolved_unzip' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
-    fi
+    done < <(extract_option_values "-d" "" || true)
   fi
 
   # --- cpio -D PATH ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])cpio($|[[:space:]])'; then
-    local cpio_dir
-    cpio_dir=$(extract_option_value "-D" "" || true)
-    if [ -n "$cpio_dir" ]; then
+    while IFS= read -r cpio_dir; do
+      [ -z "$cpio_dir" ] && continue
       cpio_dir=$(expand_path "$cpio_dir")
       if [[ "$cpio_dir" != /* ]]; then
         cpio_dir="$EFFECTIVE_CWD/$cpio_dir"
@@ -701,7 +690,7 @@ check_single_command() {
         echo "BLOCKED: 'cpio -D' targets '$resolved_cpio' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
-    fi
+    done < <(extract_option_values "-D" "" || true)
   fi
 
   # --- tee command: extract file arguments, block if outside project ---
@@ -725,10 +714,11 @@ check_single_command() {
   fi
 
   # --- curl -o / curl --output outside project ---
+  # curl -o is positional: `curl -o out1 URL1 -o out2 URL2` writes each URL
+  # to its corresponding output. Validate EVERY occurrence.
   if echo "$CMD" | grep -qE '(^|[[:space:]])curl($|[[:space:]])'; then
-    local curl_output=""
-    curl_output=$(extract_option_value "-o" "--output" || true)
-    if [ -n "$curl_output" ]; then
+    while IFS= read -r curl_output; do
+      [ -z "$curl_output" ] && continue
       curl_output=$(expand_path "$curl_output")
       if [[ "$curl_output" != /* ]]; then
         curl_output="$EFFECTIVE_CWD/$curl_output"
@@ -739,14 +729,13 @@ check_single_command() {
         echo "BLOCKED: 'curl' output file '$resolved_curl' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
-    fi
+    done < <(extract_option_values "-o" "--output" || true)
   fi
 
   # --- wget -O / wget --output-document outside project ---
   if echo "$CMD" | grep -qE '(^|[[:space:]])wget($|[[:space:]])'; then
-    local wget_output=""
-    wget_output=$(extract_option_value "-O" "--output-document" || true)
-    if [ -n "$wget_output" ]; then
+    while IFS= read -r wget_output; do
+      [ -z "$wget_output" ] && continue
       wget_output=$(expand_path "$wget_output")
       if [[ "$wget_output" != /* ]]; then
         wget_output="$EFFECTIVE_CWD/$wget_output"
@@ -757,7 +746,7 @@ check_single_command() {
         echo "BLOCKED: 'wget' output file '$resolved_wget' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
       fi
-    fi
+    done < <(extract_option_values "-O" "--output-document" || true)
   fi
 
   # --- dd of= outside project ---
@@ -795,12 +784,25 @@ check_single_command() {
     local rtok="${CMD_TOKENS[$ri]}"
     local REDIR_TARGET=""
 
-    # Scan the token for an unquoted > (respecting ' and " quotes)
+    # Scan the token for an unquoted > (respecting ' and " quotes and
+    # backslash escapes). `\>` outside single quotes is a literal >, not
+    # a redirect operator.
     local j=0 tlen=${#rtok}
     local tin_sq=0 tin_dq=0
+    local tin_esc=0
     local redir_pos=-1
     while [ $j -lt $tlen ]; do
       local tc="${rtok:$j:1}"
+      if [ $tin_esc -eq 1 ]; then
+        tin_esc=0
+        j=$((j + 1))
+        continue
+      fi
+      if [ "$tc" = "\\" ] && [ $tin_sq -eq 0 ]; then
+        tin_esc=1
+        j=$((j + 1))
+        continue
+      fi
       if [ "$tc" = "'" ] && [ $tin_dq -eq 0 ]; then
         tin_sq=$(( 1 - tin_sq ))
       elif [ "$tc" = '"' ] && [ $tin_sq -eq 0 ]; then

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -167,12 +167,14 @@ tokenize_args() {
 # Usage: extract_option_value <short> <long>
 #   short: e.g. "-o", or "" to skip
 #   long:  e.g. "--output", or "" to skip
-# Supports: "-o value", "--output value", "--output=value"
-# If an option appears multiple times, returns the LAST match — this matches
-# the "last-wins" semantics of curl/wget/cp/mv/tar and prevents a bypass where
-# an attacker places an in-project value first and an outside value second
+# Supports: "-o value", "--output value", "--output=value".
+# Option flags are matched after stripping surrounding quotes so that
+# `curl "-o" /etc/passwd` also matches. If an option appears multiple times,
+# returns the LAST match — this matches the "last-wins" semantics of
+# curl/wget/cp/mv/tar and prevents a bypass where an attacker places an
+# in-project value first and an outside value second
 # (e.g. `curl -o $PROJECT/ok -o /etc/passwd`).
-# Echoes the value (quotes preserved — caller must expand_path).
+# Echoes the value (possibly with quotes — caller must expand_path).
 # Returns 0 if found, 1 otherwise.
 extract_option_value() {
   local short="$1"
@@ -820,6 +822,10 @@ check_single_command() {
     if [ $op_end -lt $tlen ] && [ "${rtok:$op_end:1}" = ">" ]; then
       op_end=$((op_end + 1))
     fi
+    # Also consume a trailing | (Bash clobber operator: >| or >>|).
+    if [ $op_end -lt $tlen ] && [ "${rtok:$op_end:1}" = "|" ]; then
+      op_end=$((op_end + 1))
+    fi
 
     # Extract target: rest of token if any, otherwise next token
     local rest="${rtok:$op_end}"
@@ -839,6 +845,12 @@ check_single_command() {
     fi
 
     if [ -n "$REDIR_TARGET" ]; then
+      # Block process substitution — `> >(cmd)` runs `cmd` which the guard
+      # cannot safely inspect, similar to nested shells.
+      if [[ "$REDIR_TARGET" == \(* ]] || [[ "$REDIR_TARGET" == \>\(* ]] || [[ "$REDIR_TARGET" == \<\(* ]]; then
+        echo "BLOCKED: Process substitution redirect '$REDIR_TARGET' cannot be safely inspected. Ask user for explicit permission." >&2
+        exit 2
+      fi
       REDIR_TARGET=$(expand_path "$REDIR_TARGET")
       if [[ "$REDIR_TARGET" != /* ]]; then
         REDIR_TARGET="$EFFECTIVE_CWD/$REDIR_TARGET"
@@ -938,8 +950,26 @@ split_and_check() {
         fi
       fi
 
-      # Check for ; or |
-      if [ "$ch" = ";" ] || [ "$ch" = "|" ]; then
+      # Check for ;
+      if [ "$ch" = ";" ]; then
+        subcmds+=("$current")
+        current=""
+        prev_ch="$ch"
+        i=$((i + 1))
+        continue
+      fi
+
+      # Check for | — but not if it's part of the Bash clobber operator >| or >>|
+      if [ "$ch" = "|" ]; then
+        # Look at the trailing chars of current (trimmed) to detect > or >>
+        local trimmed="${current%"${current##*[![:space:]]}"}"
+        if [[ "$trimmed" == *\> ]]; then
+          # Part of >| or >>| — keep it as a redirect operator, not a pipe
+          current="${current}${ch}"
+          prev_ch="$ch"
+          i=$((i + 1))
+          continue
+        fi
         subcmds+=("$current")
         current=""
         prev_ch="$ch"

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -763,49 +763,58 @@ check_single_command() {
   fi
 
   # --- Writing to files outside project via redirection ---
-  # Walk tokens to find redirect targets. Handles:
-  #   > file, >> file, >file, >>file
-  #   1> file, 2> file, 1>file, 2>>file
-  #   &> file, &>file, &>>file
-  # Skips fd-to-fd redirects like 2>&1.
+  # Walk tokens and scan each one for an unquoted > operator anywhere
+  # (not just at the start). This catches both separated forms (`> file`,
+  # `2>> file`) and attached forms (`>file`, `x>file`, `"a">file`).
+  # Skips fd-to-fd redirects like 2>&1 (target starts with &).
   local ri=0 rn=${#CMD_TOKENS[@]}
   while [ $ri -lt $rn ]; do
     local rtok="${CMD_TOKENS[$ri]}"
     local REDIR_TARGET=""
-    local rest=""
-    local matched=0
 
-    if [[ "$rtok" =~ ^[0-9]+(\>\>?)(.*)$ ]]; then
-      rest="${BASH_REMATCH[2]}"
-      matched=1
-    elif [[ "$rtok" =~ ^\&(\>\>?)(.*)$ ]]; then
-      rest="${BASH_REMATCH[2]}"
-      matched=1
-    elif [[ "$rtok" =~ ^(\>\>?)(.*)$ ]]; then
-      rest="${BASH_REMATCH[2]}"
-      matched=1
-    fi
-
-    if [ "$matched" -eq 1 ]; then
-      if [ -z "$rest" ]; then
-        # Separated form: target is next token
-        if [ $((ri + 1)) -lt $rn ]; then
-          REDIR_TARGET="${CMD_TOKENS[$((ri + 1))]}"
-          ri=$((ri + 2))
-        else
-          ri=$((ri + 1))
-        fi
-      elif [[ "$rest" == \&* ]]; then
-        # fd-to-fd redirect like 2>&1, no file target
-        ri=$((ri + 1))
-      else
-        # Attached form: rest is the file
-        REDIR_TARGET="$rest"
-        ri=$((ri + 1))
+    # Scan the token for an unquoted > (respecting ' and " quotes)
+    local j=0 tlen=${#rtok}
+    local tin_sq=0 tin_dq=0
+    local redir_pos=-1
+    while [ $j -lt $tlen ]; do
+      local tc="${rtok:$j:1}"
+      if [ "$tc" = "'" ] && [ $tin_dq -eq 0 ]; then
+        tin_sq=$(( 1 - tin_sq ))
+      elif [ "$tc" = '"' ] && [ $tin_sq -eq 0 ]; then
+        tin_dq=$(( 1 - tin_dq ))
+      elif [ "$tc" = ">" ] && [ $tin_sq -eq 0 ] && [ $tin_dq -eq 0 ]; then
+        redir_pos=$j
+        break
       fi
-    else
+      j=$((j + 1))
+    done
+
+    if [ $redir_pos -lt 0 ]; then
       ri=$((ri + 1))
       continue
+    fi
+
+    # Found > at redir_pos. Extend past a second > if present (>>).
+    local op_end=$((redir_pos + 1))
+    if [ $op_end -lt $tlen ] && [ "${rtok:$op_end:1}" = ">" ]; then
+      op_end=$((op_end + 1))
+    fi
+
+    # Extract target: rest of token if any, otherwise next token
+    local rest="${rtok:$op_end}"
+    if [ -z "$rest" ]; then
+      if [ $((ri + 1)) -lt $rn ]; then
+        REDIR_TARGET="${CMD_TOKENS[$((ri + 1))]}"
+        ri=$((ri + 2))
+      else
+        ri=$((ri + 1))
+      fi
+    elif [[ "$rest" == \&* ]]; then
+      # fd-to-fd redirect like 2>&1, no file target
+      ri=$((ri + 1))
+    else
+      REDIR_TARGET="$rest"
+      ri=$((ri + 1))
     fi
 
     if [ -n "$REDIR_TARGET" ]; then

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -1101,6 +1101,27 @@ expect_blocked 'process substitution > >(tee outside)' \
 expect_blocked 'process substitution attached >(cmd)' \
   'echo x >>(tee /etc/passwd)'
 
+# Positional curl -o: validate EVERY occurrence, not just last
+expect_blocked 'curl positional -o first outside second inside' \
+  "curl -o /etc/passwd http://a -o \"$PROJECT/out\" http://b"
+
+expect_blocked 'curl positional -o first inside second outside' \
+  "curl -o \"$PROJECT/out\" http://a -o /etc/passwd http://b"
+
+expect_allowed 'curl positional -o both inside project' \
+  "curl -o \"$PROJECT/a\" http://a -o \"$PROJECT/b\" http://b"
+
+# Positional wget -O (same semantics concern)
+expect_blocked 'wget positional -O first outside second inside' \
+  "wget -O /etc/passwd http://a -O \"$PROJECT/out\" http://b"
+
+# Backslash-escaped > is a literal, not a redirect
+expect_allowed 'backslash-escaped > not a redirect' \
+  'echo \>/etc/passwd'
+
+expect_allowed 'backslash-escaped >> not a redirect' \
+  'echo \>\>/etc/passwd'
+
 echo ""
 
 # ============================================================

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -1052,6 +1052,35 @@ expect_blocked 'redirect x>file attached to token with quoted space path' \
 expect_allowed 'redirect x>file no whitespace inside project' \
   "echo x>\"$PROJECT/dir with space/out.txt\""
 
+# Quoted option flags: tokenize_args preserves quotes, so flag matching
+# must strip them first. Otherwise curl "-o" /etc/passwd bypasses.
+expect_blocked 'curl with quoted -o flag' \
+  'curl "-o" /etc/passwd http://x'
+
+expect_blocked 'curl with quoted --output flag' \
+  'curl "--output" /etc/passwd http://x'
+
+expect_blocked 'curl with quoted --output=value' \
+  'curl "--output=/etc/passwd" http://x'
+
+expect_blocked 'wget with quoted -O flag' \
+  'wget "-O" /etc/passwd http://x'
+
+expect_blocked 'tar with quoted -C flag' \
+  'tar "-C" /etc -xf a.tar'
+
+expect_blocked 'tar with quoted --directory= value' \
+  'tar "--directory=/etc" -xf a.tar'
+
+expect_blocked 'dd with quoted of= token' \
+  'dd if=/dev/zero "of=/etc/passwd"'
+
+expect_blocked 'mv with quoted -t flag' \
+  'mv "-t" /etc a.txt'
+
+expect_blocked 'cp with quoted --target-directory= value' \
+  'cp "--target-directory=/etc" a.txt'
+
 echo ""
 
 # ============================================================

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -1036,6 +1036,22 @@ expect_blocked 'mv repeated -t last wins to outside' \
 expect_blocked 'cp repeated --target-directory last wins to outside' \
   "cp --target-directory \"$PROJECT\" --target-directory /etc a.txt"
 
+# Attached-form redirects (no whitespace before >)
+expect_blocked 'redirect x>file no whitespace traversal' \
+  "echo x>/etc/passwd"
+
+expect_blocked 'redirect x>>file no whitespace traversal' \
+  "echo x>>/etc/passwd"
+
+expect_blocked 'redirect "x">file quoted no whitespace' \
+  'echo "x">/etc/passwd'
+
+expect_blocked 'redirect x>file attached to token with quoted space path' \
+  "echo x>\"$PROJECT/safe /../../etc/passwd\""
+
+expect_allowed 'redirect x>file no whitespace inside project' \
+  "echo x>\"$PROJECT/dir with space/out.txt\""
+
 echo ""
 
 # ============================================================

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -965,6 +965,48 @@ expect_blocked 'redirect >> quoted space traversal' \
 expect_allowed 'redirect > quoted space inside project' \
   "echo x > \"$PROJECT/dir with space/out.txt\""
 
+# fd-prefixed redirects: 1>, 2>, 2>>, &>, &>>
+expect_blocked 'redirect 1> quoted space traversal' \
+  "echo x 1> \"$PROJECT/safe /../../etc/passwd\""
+
+expect_blocked 'redirect 2> quoted space traversal' \
+  "echo x 2> \"$PROJECT/safe /../../etc/passwd\""
+
+expect_blocked 'redirect 2>> quoted space traversal' \
+  "echo x 2>> \"$PROJECT/safe /../../etc/passwd\""
+
+expect_blocked 'redirect &> quoted space traversal' \
+  "echo x &> \"$PROJECT/safe /../../etc/passwd\""
+
+expect_blocked 'redirect 2>file attached form outside project' \
+  "echo x 2>/etc/passwd"
+
+expect_allowed 'redirect 2> inside project' \
+  "echo x 2> \"$PROJECT/dir with space/err.txt\""
+
+expect_allowed 'redirect &> inside project' \
+  "echo x &> \"$PROJECT/dir with space/all.txt\""
+
+# fd-to-fd redirect must not be treated as a file target
+expect_allowed 'redirect 2>&1 (fd-to-fd, not a file)' \
+  "echo x 2>&1"
+
+# Repeated options: last one wins — must validate all occurrences
+expect_blocked 'tar repeated -C last wins to outside' \
+  "tar -C \"$PROJECT\" -C /etc -xf archive.tar"
+
+expect_blocked 'tar repeated -C first inside, second outside' \
+  "tar -C \"$PROJECT/dir with space\" -C /tmp -xf archive.tar"
+
+expect_allowed 'tar repeated -C both inside project' \
+  "tar -C \"$PROJECT\" -C \"$PROJECT/dir with space\" -xf archive.tar"
+
+expect_blocked 'dd repeated of= last wins to outside' \
+  "dd if=/dev/zero of=\"$PROJECT/ok\" of=/etc/passwd"
+
+expect_blocked 'dd repeated of= first inside, second outside' \
+  "dd if=/dev/zero of=\"$PROJECT/dir with space/ok\" of=/etc/passwd"
+
 echo ""
 
 # ============================================================

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -1081,6 +1081,26 @@ expect_blocked 'mv with quoted -t flag' \
 expect_blocked 'cp with quoted --target-directory= value' \
   'cp "--target-directory=/etc" a.txt'
 
+# Bash clobber operator >| / >>| — | is part of the operator, not a pipe
+expect_blocked 'clobber >| to outside project' \
+  'echo x >| /etc/passwd'
+
+expect_blocked 'clobber >|file attached to outside' \
+  'echo x >|/etc/passwd'
+
+expect_blocked 'clobber >>| append to outside' \
+  'echo x >>| /etc/passwd'
+
+expect_allowed 'clobber >| inside project' \
+  "echo x >| \"$PROJECT/dir with space/out.txt\""
+
+# Process substitution > >(cmd) — uninspectable, must block
+expect_blocked 'process substitution > >(tee outside)' \
+  'echo x > >(tee /etc/passwd)'
+
+expect_blocked 'process substitution attached >(cmd)' \
+  'echo x >>(tee /etc/passwd)'
+
 echo ""
 
 # ============================================================

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -880,6 +880,94 @@ expect_allowed "rsync inside project" \
 echo ""
 
 # ============================================================
+# 45d. Option extractors with quoted space + traversal (#6)
+# ============================================================
+echo "--- Option extractors: quoted space + traversal ---"
+
+# Set up a subdir inside project so prefix matches before traversal
+mkdir -p "$PROJECT/safe"
+mkdir -p "$PROJECT/dir with space"
+
+# curl -o / --output / --output=
+expect_blocked 'curl -o quoted space traversal' \
+  "curl -o \"$PROJECT/safe /../../etc/passwd\" http://x"
+
+expect_blocked 'curl --output quoted space traversal' \
+  "curl --output \"$PROJECT/safe /../../etc/passwd\" http://x"
+
+expect_blocked 'curl --output= quoted space traversal' \
+  "curl --output=\"$PROJECT/safe /../../etc/passwd\" http://x"
+
+expect_allowed 'curl -o quoted space inside project' \
+  "curl -o \"$PROJECT/dir with space/out.txt\" http://x"
+
+# wget -O / --output-document / --output-document=
+expect_blocked 'wget -O quoted space traversal' \
+  "wget -O \"$PROJECT/safe /../../etc/passwd\" http://x"
+
+expect_blocked 'wget --output-document= quoted space traversal' \
+  "wget --output-document=\"$PROJECT/safe /../../etc/passwd\" http://x"
+
+expect_allowed 'wget -O quoted space inside project' \
+  "wget -O \"$PROJECT/dir with space/out.txt\" http://x"
+
+# tar -C / --directory / --directory=
+expect_blocked 'tar -C quoted space traversal' \
+  "tar -C \"$PROJECT/safe /../../etc\" -xf a.tar"
+
+expect_blocked 'tar --directory= quoted space traversal' \
+  "tar --directory=\"$PROJECT/safe /../../etc\" -xf a.tar"
+
+expect_allowed 'tar -C quoted space inside project' \
+  "tar -C \"$PROJECT/dir with space\" -xf a.tar"
+
+# unzip -d
+expect_blocked 'unzip -d quoted space traversal' \
+  "unzip -d \"$PROJECT/safe /../../etc\" a.zip"
+
+expect_allowed 'unzip -d quoted space inside project' \
+  "unzip -d \"$PROJECT/dir with space\" a.zip"
+
+# cpio -D
+expect_blocked 'cpio -D quoted space traversal' \
+  "cpio -D \"$PROJECT/safe /../../etc\" -i"
+
+# dd of=
+expect_blocked 'dd of= quoted space traversal' \
+  "dd if=/dev/zero of=\"$PROJECT/safe /../../etc/passwd\""
+
+expect_allowed 'dd of= quoted space inside project' \
+  "dd if=/dev/zero of=\"$PROJECT/dir with space/file.bin\""
+
+# mv/cp --target-directory / -t
+expect_blocked 'mv --target-directory= quoted space traversal' \
+  "mv --target-directory=\"$PROJECT/safe /../../tmp\" a.txt"
+
+expect_blocked 'cp --target-directory= quoted space traversal' \
+  "cp --target-directory=\"$PROJECT/safe /../../tmp\" a.txt"
+
+expect_blocked 'mv -t quoted space traversal' \
+  "mv -t \"$PROJECT/safe /../../tmp\" a.txt"
+
+expect_blocked 'cp -t quoted space traversal' \
+  "cp -t \"$PROJECT/safe /../../tmp\" a.txt"
+
+expect_allowed 'mv -t quoted space inside project' \
+  "mv -t \"$PROJECT/dir with space\" a.txt"
+
+# Redirect > / >>
+expect_blocked 'redirect > quoted space traversal' \
+  "echo x > \"$PROJECT/safe /../../etc/passwd\""
+
+expect_blocked 'redirect >> quoted space traversal' \
+  "echo x >> \"$PROJECT/safe /../../etc/passwd\""
+
+expect_allowed 'redirect > quoted space inside project' \
+  "echo x > \"$PROJECT/dir with space/out.txt\""
+
+echo ""
+
+# ============================================================
 # 46. cwd from hook event payload
 # ============================================================
 echo "--- cwd from hook event ---"

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -908,6 +908,9 @@ expect_blocked 'wget -O quoted space traversal' \
 expect_blocked 'wget --output-document= quoted space traversal' \
   "wget --output-document=\"$PROJECT/safe /../../etc/passwd\" http://x"
 
+expect_blocked 'wget --output-document quoted space traversal (separated)' \
+  "wget --output-document \"$PROJECT/safe /../../etc/passwd\" http://x"
+
 expect_allowed 'wget -O quoted space inside project' \
   "wget -O \"$PROJECT/dir with space/out.txt\" http://x"
 
@@ -943,8 +946,14 @@ expect_allowed 'dd of= quoted space inside project' \
 expect_blocked 'mv --target-directory= quoted space traversal' \
   "mv --target-directory=\"$PROJECT/safe /../../tmp\" a.txt"
 
+expect_blocked 'mv --target-directory quoted space traversal (separated)' \
+  "mv --target-directory \"$PROJECT/safe /../../tmp\" a.txt"
+
 expect_blocked 'cp --target-directory= quoted space traversal' \
   "cp --target-directory=\"$PROJECT/safe /../../tmp\" a.txt"
+
+expect_blocked 'cp --target-directory quoted space traversal (separated)' \
+  "cp --target-directory \"$PROJECT/safe /../../tmp\" a.txt"
 
 expect_blocked 'mv -t quoted space traversal' \
   "mv -t \"$PROJECT/safe /../../tmp\" a.txt"
@@ -1006,6 +1015,26 @@ expect_blocked 'dd repeated of= last wins to outside' \
 
 expect_blocked 'dd repeated of= first inside, second outside' \
   "dd if=/dev/zero of=\"$PROJECT/dir with space/ok\" of=/etc/passwd"
+
+# Repeated -o/-O/-t options with last-wins bypass: extract_option_value
+# must return the LAST match so the effective value is validated.
+expect_blocked 'curl repeated -o last wins to outside' \
+  "curl -o \"$PROJECT/ok.txt\" -o /etc/passwd http://x"
+
+expect_blocked 'curl repeated --output last wins to outside' \
+  "curl --output \"$PROJECT/ok.txt\" --output /etc/passwd http://x"
+
+expect_blocked 'wget repeated -O last wins to outside' \
+  "wget -O \"$PROJECT/ok.txt\" -O /etc/passwd http://x"
+
+expect_blocked 'wget repeated --output-document last wins to outside' \
+  "wget --output-document \"$PROJECT/ok.txt\" --output-document /etc/passwd http://x"
+
+expect_blocked 'mv repeated -t last wins to outside' \
+  "mv -t \"$PROJECT\" -t /etc a.txt"
+
+expect_blocked 'cp repeated --target-directory last wins to outside' \
+  "cp --target-directory \"$PROJECT\" --target-directory /etc a.txt"
 
 echo ""
 


### PR DESCRIPTION
## Summary

Fixes #6 — a **High severity** boundary bypass in option-style path extractors. A quoted path containing space + path traversal (e.g. `curl -o "\$PROJECT/safe /../../etc/passwd"`) was only checked against the truncated prefix, bypassing the guard.

## Root cause

Several extractors used regex `[^ ]+` to capture option values. This stops at the first space, so quoted values with internal spaces were only partially inspected.

## Fix

Strategy (b) from Codex review: tokenize the command once with the existing quote-aware `tokenize_args()`, then walk the token array for option values via a new helper `extract_option_value()`.

- Added `extract_option_value <short> <long>` helper that supports `-o value`, `--output value`, and `--output=value` forms
- Tokenization happens once per command at the top of `check_single_command` (stored in `CMD_TOKENS`)
- Replaced 8 regex-based extractors with the helper
- Rewrote redirect handling as a dedicated token walker (handles `>`, `>>`, `>file`, `>>file`)
- `dd of=` uses a direct token walk since it's key=value syntax, not standard long options

## Affected extractors

- `curl -o` / `--output` / `--output=`
- `wget -O` / `--output-document` / `--output-document=`
- `tar -C` / `--directory` / `--directory=`
- `unzip -d`
- `cpio -D`
- `dd of=`
- `mv/cp -t` / `--target-directory` / `--target-directory=`
- `>` / `>>` redirect

## Test plan

- [x] 264 tests pass locally (macOS) — 23 new
- [x] All 11 attack scenarios from #6 now return exit 2 (BLOCKED)
- [ ] CI passes on Ubuntu and macOS
- [x] No regressions in existing tests

New tests cover, for each extractor:
- Attack variant: quoted path with space + `..` traversal → BLOCKED
- Valid variant: quoted path with space inside project → ALLOWED
- Both short (`-t`) and long (`--target-directory=`) option forms
- Separated (`> file`) and attached (`>file`) redirect forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)