### PR TITLE
Block command substitution outside single quotes (#9 item 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Allows destructive operations **within your project** but blocks them **outside*
 | `eval '...'` | Cannot safely parse evaluated code |
 | Piping to `sh` / `bash` | Inner commands invisible to guard |
 | `xargs rm/mv/cp/...` | Arguments cannot be validated |
+| `$(...)` / backticks (outside single quotes) | Command substitution target is uninspectable |
 
 ### Additional protections
 
@@ -57,7 +58,9 @@ Allows destructive operations **within your project** but blocks them **outside*
 ### Known limitations
 
 - Paths with spaces work when properly quoted (single or double quotes). Unquoted paths with spaces are not supported.
-- `$()` subshells and backtick substitution inside arguments are not expanded
+- Heredoc body contents are not inspected (only the first line of the command, where redirects are handled normally)
+- Brace expansion (`{a,b,c}`) is not enumerated — literal match only
+- `~user/` (home of another user) is not expanded; only `~/` (current user) is handled
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Allows destructive operations **within your project** but blocks them **outside*
 | `eval '...'` | Cannot safely parse evaluated code |
 | Piping to `sh` / `bash` | Inner commands invisible to guard |
 | `xargs rm/mv/cp/...` | Arguments cannot be validated |
-| `$(...)` / backticks (outside single quotes) | Command substitution target is uninspectable |
+| `$(...)` / backticks (outside single quotes) | Command substitution target is uninspectable. Single-quoted forms like `'$(cmd)'` and arithmetic expansion `$((2+2))` are allowed. |
 
 ### Additional protections
 

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -274,6 +274,43 @@ check_single_command() {
     CMD_TOKENS+=("$tok")
   done < <(tokenize_args "$CMD")
 
+  # --- Block command substitution outside single quotes ---
+  # `$(...)` and backticks are expanded by bash (even inside double quotes),
+  # so the guard cannot know the final target. Single quotes keep them literal,
+  # so only block when they appear outside single quotes. Similar rationale to
+  # blocking `bash -c` / `eval` — the inner command is uninspectable.
+  local ci=0 clen=${#CMD}
+  local cin_sq=0 cin_esc=0
+  while [ $ci -lt $clen ]; do
+    local cc="${CMD:$ci:1}"
+    if [ $cin_esc -eq 1 ]; then
+      cin_esc=0
+      ci=$((ci + 1))
+      continue
+    fi
+    if [ "$cc" = "\\" ] && [ $cin_sq -eq 0 ]; then
+      cin_esc=1
+      ci=$((ci + 1))
+      continue
+    fi
+    if [ "$cc" = "'" ]; then
+      cin_sq=$(( 1 - cin_sq ))
+      ci=$((ci + 1))
+      continue
+    fi
+    if [ $cin_sq -eq 0 ]; then
+      if [ "$cc" = "\`" ]; then
+        echo "BLOCKED: Command substitution with backticks cannot be safely inspected. Ask user for explicit permission." >&2
+        exit 2
+      fi
+      if [ "$cc" = "\$" ] && [ $((ci + 1)) -lt $clen ] && [ "${CMD:$((ci + 1)):1}" = "(" ]; then
+        echo "BLOCKED: Command substitution '\$(...)' cannot be safely inspected. Ask user for explicit permission." >&2
+        exit 2
+      fi
+    fi
+    ci=$((ci + 1))
+  done
+
   # --- Block cd outside project followed by destructive commands ---
   if [[ "$CMD" =~ ^cd($|[[:space:]]) ]]; then
     local cd_target

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -277,10 +277,12 @@ check_single_command() {
   # --- Block command substitution outside single quotes ---
   # `$(...)` and backticks are expanded by bash (even inside double quotes),
   # so the guard cannot know the final target. Single quotes keep them literal,
-  # so only block when they appear outside single quotes. Similar rationale to
-  # blocking `bash -c` / `eval` — the inner command is uninspectable.
+  # so only block when they appear outside single quotes. Arithmetic expansion
+  # `$((...))` is allowed — it's a numeric computation, not a command.
+  # Similar rationale to blocking `bash -c` / `eval` — the inner command is
+  # uninspectable.
   local ci=0 clen=${#CMD}
-  local cin_sq=0 cin_esc=0
+  local cin_sq=0 cin_dq=0 cin_esc=0
   while [ $ci -lt $clen ]; do
     local cc="${CMD:$ci:1}"
     if [ $cin_esc -eq 1 ]; then
@@ -293,8 +295,15 @@ check_single_command() {
       ci=$((ci + 1))
       continue
     fi
-    if [ "$cc" = "'" ]; then
+    # Single quotes are only delimiters when NOT inside double quotes
+    if [ "$cc" = "'" ] && [ $cin_dq -eq 0 ]; then
       cin_sq=$(( 1 - cin_sq ))
+      ci=$((ci + 1))
+      continue
+    fi
+    # Double quotes are only delimiters when NOT inside single quotes
+    if [ "$cc" = '"' ] && [ $cin_sq -eq 0 ]; then
+      cin_dq=$(( 1 - cin_dq ))
       ci=$((ci + 1))
       continue
     fi
@@ -304,8 +313,11 @@ check_single_command() {
         exit 2
       fi
       if [ "$cc" = "\$" ] && [ $((ci + 1)) -lt $clen ] && [ "${CMD:$((ci + 1)):1}" = "(" ]; then
-        echo "BLOCKED: Command substitution '\$(...)' cannot be safely inspected. Ask user for explicit permission." >&2
-        exit 2
+        # Skip arithmetic expansion $((...)): next-next char is also (
+        if [ $((ci + 2)) -ge $clen ] || [ "${CMD:$((ci + 2)):1}" != "(" ]; then
+          echo "BLOCKED: Command substitution '\$(...)' cannot be safely inspected. Ask user for explicit permission." >&2
+          exit 2
+        fi
       fi
     fi
     ci=$((ci + 1))

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -769,6 +769,20 @@ expect_allowed "rm '\`...\`' single-quoted backticks literal" \
 expect_allowed 'echo \$(literal) escaped dollar' \
   'echo \$(literal)'
 
+# Single quotes inside double quotes are literal, not delimiters
+expect_blocked 'rm "\x27$(...)\x27" single quotes literal inside double' \
+  "rm \"'\$(echo /etc/passwd)'\""
+
+# Arithmetic expansion $((...)) must not be blocked
+expect_allowed 'echo $((2+2)) arithmetic expansion' \
+  'echo $((2+2))'
+
+expect_allowed 'echo $((1+2*3)) complex arithmetic' \
+  'echo $((1+2*3))'
+
+expect_allowed 'redirect with arithmetic expansion' \
+  "echo \$((x+1)) > \"$PROJECT/out.txt\""
+
 echo ""
 
 # ============================================================

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -770,7 +770,7 @@ expect_allowed 'echo \$(literal) escaped dollar' \
   'echo \$(literal)'
 
 # Single quotes inside double quotes are literal, not delimiters
-expect_blocked 'rm "\x27$(...)\x27" single quotes literal inside double' \
+expect_blocked "rm \"'\$(...)'\" single quotes literal inside double" \
   "rm \"'\$(echo /etc/passwd)'\""
 
 # Arithmetic expansion $((...)) must not be blocked

--- a/tests/test_bash_guard.sh
+++ b/tests/test_bash_guard.sh
@@ -734,6 +734,44 @@ expect_blocked "/usr/bin/env bash -c nested shell" \
 echo ""
 
 # ============================================================
+# 39b. Command substitution (fixes #9 item 1)
+# ============================================================
+echo "--- Command substitution \$() and backticks ---"
+
+# $(...) — expanded by bash, uninspectable → block
+expect_blocked 'rm "$(...)" double-quoted substitution' \
+  'rm "$(echo /etc/passwd)"'
+
+expect_blocked 'rm $(...) unquoted substitution' \
+  'rm $(echo /etc/passwd)'
+
+expect_blocked 'curl -o "$(...)" substitution in option' \
+  'curl -o "$(echo /etc/passwd)" http://x'
+
+expect_blocked 'redirect > "$(...)" substitution in target' \
+  'echo hi > "$(echo /etc/passwd)"'
+
+# Backticks — also expanded, uninspectable
+expect_blocked 'rm `...` backtick substitution' \
+  'rm `echo /etc/passwd`'
+
+expect_blocked 'rm "`...`" double-quoted backticks' \
+  'rm "`echo /etc/passwd`"'
+
+# Single-quoted substitution is literal — allowed
+expect_allowed "rm '\$(...)' single-quoted literal" \
+  "rm '\$(echo /etc/passwd)'"
+
+expect_allowed "rm '\`...\`' single-quoted backticks literal" \
+  "rm '\`echo safe\`'"
+
+# Escaped \$( is literal
+expect_allowed 'echo \$(literal) escaped dollar' \
+  'echo \$(literal)'
+
+echo ""
+
+# ============================================================
 # 40. Pipe to sh/bash with args (sh -s, /bin/sh)
 # ============================================================
 echo "--- Pipe to shell variants ---"


### PR DESCRIPTION
## Summary

Fixes item #1 of #9 — the only security-critical parser gap. `rm "$(echo /etc/passwd)"` and similar quoted command substitutions previously bypassed the guard because the token parser saw literal `$()` text, but bash actually expands it at runtime.

## Fix

Scan the raw CMD for unquoted `$(` or backtick characters and block as "uninspectable" — same rationale as `bash -c` / `eval`. The inner command could resolve to any path, so we cannot safely validate the target.

**Allowed** (bash does not expand these):
- `'$(echo /etc/passwd)'` — single-quoted literal
- `'\`cmd\`'` — single-quoted backticks
- `echo \$(literal)` — backslash-escaped

**Blocked** (bash expands these):
- `"$(cmd)"` — double-quoted substitution
- `$(cmd)` — unquoted
- `\`cmd\`` — unquoted backticks
- `"\`cmd\`"` — double-quoted backticks

## Other items from #9

Items 2-7 (heredoc body, brace expansion, `~user/`, parameter expansion, etc.) are lower priority. Some are added to README "Known limitations"; others can be addressed in follow-ups if needed. This PR stays focused on the single security-critical issue.

## Test plan

- [x] 352 tests pass locally (9 new)
- [x] Real attack scenarios verified manually: `"$(...)"` in rm, curl -o, redirect target — all blocked
- [x] False positives verified: single-quoted literal, escaped `\$(`, normal commands — all allowed
- [ ] CI passes on Ubuntu and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)