### PR TITLE
guard: exempt /dev/null in discard-only walkers (curl-o, tee, redirect, wget-O, dd-of)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Allows destructive operations **within your project** but blocks them **outside*
 - **Path traversal** — `..` segments are resolved before boundary check
 - **`~` and `$HOME` expansion** — `rm ~/file` and `rm $HOME/file` are correctly detected as outside-project
 - **Symlink resolution** — handles macOS `/var` → `/private/var`, dereferences symlink chains in Edit/Write/MultiEdit (fail-closed after 20 hops)
+- **`/dev/null` bit-bucket** — `curl -o /dev/null`, `2>/dev/null`, `tee /dev/null`, `dd of=/dev/null`, and all redirect target forms are allowed so routine probe and silencing workflows don't hit the boundary. Narrow exemption: the discard-only walkers short-circuit *before* `is_write_permitted`; `sed -i /dev/null`, `truncate /dev/null`, and `cp|mv|ln ... /dev/null` remain blocked because each performs a real filesystem write under `/dev/`.
 
 ### Path allowlist (`hooks/allowlist.conf`)
 

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -408,6 +408,30 @@ command_name_is() {
   return 1
 }
 
+is_discard_target() {
+  # Return 0 iff $1 is a POSIX bit-bucket write target whose bytes are
+  # guaranteed to be discarded with no real filesystem write.
+  #
+  # /dev/null is the canonical bit-bucket on every POSIX system
+  # (Linux, macOS, BSD) at the same path. Writes to it are accepted
+  # by the kernel and dropped — there is no filesystem target, no
+  # parent directory mutation, no symlink side-effect. Callers that
+  # KNOW they are writing a target (redirect operators, `tee`,
+  # `curl -o`, `wget -O`, `dd of=`) can short-circuit here before
+  # invoking is_write_permitted, so probe and silencing workflows
+  # like `curl -o /dev/null` and `2>/dev/null` don't require a
+  # per-project allowlist entry.
+  #
+  # IMPORTANT: this must NOT be used from call sites that do an
+  # in-place edit via temp-file + rename (`sed -i`, `truncate`) or
+  # from `cp/mv/ln/install/rsync` targets — those DO write under
+  # the parent directory of the nominal target (e.g. sed -i creates
+  # a temp file in /dev/ before renaming over /dev/null), and the
+  # boundary check must still fire there. See is_write_permitted
+  # docstring for the full separation of write semantics.
+  [ "$1" = "/dev/null" ]
+}
+
 is_shell_token() {
   local _t="$1"
   local _base="${_t##*/}"
@@ -1815,6 +1839,8 @@ check_single_command() {
       fi
       RESOLVED=$(resolve_path "$TARGET")
 
+      # /dev/null is a discard sink for tee (`echo x | tee /dev/null`).
+      is_discard_target "$RESOLVED" && continue
       if ! is_write_permitted "$RESOLVED"; then
         echo "BLOCKED: 'tee' targets '$RESOLVED' which is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
@@ -1834,6 +1860,8 @@ check_single_command() {
       fi
       local resolved_curl
       resolved_curl=$(resolve_path "$curl_output")
+      # /dev/null is a discard sink for HTTP probes (`curl -o /dev/null -w %{http_code}`).
+      is_discard_target "$resolved_curl" && continue
       if ! is_write_permitted "$resolved_curl"; then
         echo "BLOCKED: 'curl' output file '$resolved_curl' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
@@ -1851,6 +1879,8 @@ check_single_command() {
       fi
       local resolved_wget
       resolved_wget=$(resolve_path "$wget_output")
+      # /dev/null is a discard sink (`wget -O /dev/null URL`).
+      is_discard_target "$resolved_wget" && continue
       if ! is_write_permitted "$resolved_wget"; then
         echo "BLOCKED: 'wget' output file '$resolved_wget' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
         exit 2
@@ -1874,9 +1904,12 @@ check_single_command() {
           fi
           local resolved_dd
           resolved_dd=$(resolve_path "$dd_output")
-          if ! is_write_permitted "$resolved_dd"; then
-            echo "BLOCKED: 'dd' output '$resolved_dd' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-            exit 2
+          # /dev/null is a discard sink (`dd if=x of=/dev/null`).
+          if ! is_discard_target "$resolved_dd"; then
+            if ! is_write_permitted "$resolved_dd"; then
+              echo "BLOCKED: 'dd' output '$resolved_dd' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+              exit 2
+            fi
           fi
         fi
       fi
@@ -1993,9 +2026,13 @@ check_single_command() {
         echo "BLOCKED: Redirect target symlink chain too deep or circular at '$resolved_redir'. Ask user for explicit permission." >&2
         exit 2
       fi
-      if ! is_write_permitted "$resolved_redir"; then
-        echo "BLOCKED: Redirect target '$resolved_redir' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
-        exit 2
+      # /dev/null is a discard sink for every redirect form
+      # (`> /dev/null`, `2> /dev/null`, `&> /dev/null`, `2>&1 > /dev/null`).
+      if ! is_discard_target "$resolved_redir"; then
+        if ! is_write_permitted "$resolved_redir"; then
+          echo "BLOCKED: Redirect target '$resolved_redir' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
+          exit 2
+        fi
       fi
     fi
   done

--- a/tests/test_true_negatives.sh
+++ b/tests/test_true_negatives.sh
@@ -528,6 +528,63 @@ expect_allowed "grep pattern PROJECT/file"      "grep pattern $PROJECT/README.md
 echo ""
 
 # ============================================================
+# /dev/null exemption — universal POSIX bit-bucket
+# ------------------------------------------------------------
+# /dev/null discards every byte written to it and exists on every
+# POSIX system at the same path. is_write_permitted itself is NOT
+# permissive for /dev/null — it still treats the path as outside
+# any project. The exemption is applied at specific walker call
+# sites (redirect, tee, curl -o, wget -O, dd of=) by short-
+# circuiting via is_discard_target BEFORE is_write_permitted runs,
+# so legitimate probe and silencing workflows pass without loosening
+# the shared helper for every caller.
+# ============================================================
+echo "--- /dev/null exemption (universal bit-bucket) ---"
+
+expect_allowed "curl -o /dev/null (HTTP probe / status check)" \
+  "curl -o /dev/null -w '%{http_code}' https://example.com/"
+
+expect_allowed "wget -O /dev/null (HTTP probe)" \
+  "wget -O /dev/null https://example.com/"
+
+expect_allowed "redirect > /dev/null (silence stdout)" \
+  "echo noisy > /dev/null"
+
+expect_allowed "redirect 2> /dev/null (silence stderr)" \
+  "some_cmd 2> /dev/null"
+
+expect_allowed "redirect &> /dev/null (silence both)" \
+  "some_cmd &> /dev/null"
+
+expect_allowed "tee /dev/null (no-op tee)" \
+  "echo x | tee /dev/null"
+
+expect_allowed "dd of=/dev/null (discard)" \
+  "dd if=$PROJECT/README.md of=/dev/null bs=1"
+
+# Counterexamples — non-discard contexts must STAY blocked even when the
+# target happens to be /dev/null. Codex review on the proof-of-concept
+# flagged that sed -i rewrites via a temp file + rename in the target's
+# parent directory (/dev/), so /dev/null must not be uniformly exempted.
+# These regression assertions keep the narrow-scope design honest.
+expect_blocked "sed -i /dev/null (writes temp file under /dev/)" \
+  "sed -i 's/a/b/' /dev/null"
+
+expect_blocked "truncate -s 0 /dev/null (modifies real file node)" \
+  "truncate -s 0 /dev/null"
+
+expect_blocked "cp src /dev/null (destination, real filesystem write)" \
+  "cp $PROJECT/README.md /dev/null"
+
+expect_blocked "mv src /dev/null (destination, real filesystem write)" \
+  "mv $PROJECT/README.md /dev/null"
+
+expect_blocked "ln -sf src /dev/null (symlink target replaces device node)" \
+  "ln -sf $PROJECT/README.md /dev/null"
+
+echo ""
+
+# ============================================================
 # <<\EOF backslash-escaped heredoc delimiter: sed/truncate/redirect
 # walkers must NOT false-positive on body bytes.
 # ------------------------------------------------------------


### PR DESCRIPTION
## Summary

Allow `/dev/null` as a write target in the five Bash walkers that genuinely discard bytes (redirect, `tee`, `curl -o`, `wget -O`, `dd of=`) so routine probe and silencing workflows don't need a per-project allowlist entry. Narrow-scoped: `is_write_permitted` stays strict for every other caller, including `sed -i`, `truncate`, `cp`, `mv`, `ln`, `install`, `rsync`, and the Edit/Write tool.

## Why

Real user pain across every project using this plugin: the path-boundary check fires on `/dev/null` because it resolves outside any project directory. Every legitimate POSIX probe/silence idiom gets blocked:

```
curl -o /dev/null -w '%{http_code}' URL   # HTTP status probe
wget -O /dev/null URL
git fetch 2>/dev/null                     # silence stderr
cmd &>/dev/null                           # silence both
echo x | tee /dev/null                    # no-op tee
dd if=src of=/dev/null bs=1               # discard sink
```

None of these touch a real filesystem target; bash sends the bytes to the kernel bit-bucket. `/dev/null` is a universal POSIX primitive, not a project-specific path, so `hooks/allowlist.conf` is the wrong mechanism.

## Design iteration — Codex review gate

**Attempt 1** (rejected, not pushed): I initially short-circuited inside `is_write_permitted` with a context flag. Codex review flagged a **P1 regression** — the exemption applied uniformly to every caller, including `sed -i` which rewrites via a temp file + rename in the target's *parent* directory. `sed -i '...' /dev/null` would have opened an outside-project write path that the previous guard correctly blocked.

> Codex verbatim: *"This short-circuit now applies to every Bash caller of `is_write_permitted`, not just redirections/`curl -o`/`dd`. That means the guard now allows commands such as `sed -i 's/x/y/' /dev/null`, even though in-place sed rewrites via a temp file + rename in `/dev`, which is a real write outside the project boundary."*

**Attempt 2** (this PR): narrow exemption at the known discard-only call sites only. New `is_discard_target` helper returns 0 iff the resolved path is exactly `/dev/null`, called **before** `is_write_permitted` at five walkers that genuinely discard bytes. Every other caller of `is_write_permitted` retains strict boundary semantics — Codex's P1 concern is preserved.

## What changed

- **`hooks/guard.sh`:**
  - New `is_discard_target` helper (~25 lines including docstring that explicitly lists which call sites MAY use it and which MUST NOT).
  - Five walkers patched with a one-line `is_discard_target` short-circuit + inline comment: redirect (`>`, `2>`, `&>`, `2>&1 >`), `tee`, `curl -o / --output`, `wget -O / --output-document`, `dd of=`.
- **`README.md`:** one bullet under "Additional protections" documenting the exemption and its boundary (what stays blocked).
- **`tests/test_true_negatives.sh`:**
  - 7 `expect_allowed` positives — every discard walker path.
  - 5 `expect_blocked` counterexamples — `sed -i`, `truncate`, `cp`, `mv`, `ln` with `/dev/null` as target must stay blocked. These are the Codex P1 regression lock-ins.

## What stays blocked (regression coverage in this PR)

| Command | Before | After |
|---|---|---|
| `sed -i '...' /dev/null` | BLOCKED | BLOCKED ✓ (Codex P1) |
| `truncate -s 0 /dev/null` | BLOCKED | BLOCKED ✓ |
| `cp src /dev/null` | BLOCKED | BLOCKED ✓ |
| `mv src /dev/null` | BLOCKED | BLOCKED ✓ |
| `ln -sf src /dev/null` | BLOCKED | BLOCKED ✓ |
| `Write tool, file_path=/dev/null` | BLOCKED | BLOCKED ✓ |

## What flips from BLOCKED to ALLOWED

| Command | Before | After |
|---|---|---|
| `curl -o /dev/null -w '%{http_code}' URL` | BLOCKED | ALLOWED |
| `wget -O /dev/null URL` | BLOCKED | ALLOWED |
| `echo x > /dev/null` | BLOCKED | ALLOWED |
| `cmd 2> /dev/null` | BLOCKED | ALLOWED |
| `cmd &> /dev/null` | BLOCKED | ALLOWED |
| `echo x | tee /dev/null` | BLOCKED | ALLOWED |
| `dd if=src of=/dev/null` | BLOCKED | ALLOWED |

## Test plan

- [x] `bash tests/test_guard.sh` — 727/727 green locally (was 715; +7 positives, +5 regressions).
- [x] Scratch probe confirms every "after" allowed case passes and every Codex-P1 regression stays blocked.
- [x] Full `is_write_permitted` call-site audit — only the five discard walkers short-circuit; eleven other callers (Edit/Write, tar-C, unzip-d, cpio-D, in-place sed, truncate, cp, mv, ln, install, rsync) remain strict.
- [ ] CI green on ubuntu-latest, macos-latest, GitGuardian.

## Out of scope

- Other device paths (`/dev/zero`, `/dev/random`, `/dev/tty`, `/dev/stdout`, etc.). Extension point obvious in `is_discard_target`; add cases as concrete workflows surface.
- `2>&1` fd-duplication is already handled upstream in the walker (skips `&N` targets).
