### PR TITLE
v1.8.0: close 3 install/rsync walker bypass categories

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-boundary",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Blocks destructive commands outside the project directory. Allows file operations within the project (refactoring, cleanup) but prevents accidental damage outside it.",
   "author": {
     "name": "Justyna Wojtczak",

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Local Claude Code settings with workstation-specific permissions / paths.
 # Not portable across checkouts; keep out of history.
 .claude/
+
+# Revive plugin cache (per-checkout; not portable).
+.revive/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.8.0] — 2026-04-27
+
+### Security — closes 3 bypass categories in `install` / `rsync` walkers
+
+- **A. `install` POSIX double-dash bypass** — the `install` walker treated `--` as just another flag-looking token and walked past it, so a quoted `"--"` (or even bare `--`) followed by an outside-project target slipped through. Reproducers added first (`c571b91`), fix in `b460e57`: detect end-of-options and validate the next operand against the project boundary like any other write target.
+- **B. `rsync` POSIX double-dash bypass** — same shape as A in the `rsync` walker (`d8c40c1` reproducers, `5b11dbe` fix). The follow-up `ce011af` strips surrounding quotes before the `--` test in both walkers so `"--"` and `'--'` cannot smuggle the marker past the comparison.
+- **C. `install` mode/user_group flag-skip bypass** — the walker's flag-skip logic for `-m MODE` / `-o OWNER` / `-g GROUP` consumed the *next* token without validating it, so an attacker could feed an outside-project path as the "value" and the real target after it was never scanned. Reproducers in `f34fb48`, fix in `bab3ffe`.
+
+### Hardening — Codex review follow-ups on the C-class fix
+
+- **Surgical flag-skip with quote-aware comparison + value validation** (`bb9e2c3`, `f76ec34`) — the broad strip_quotes pass over every token introduced a P2 false positive on legitimate flag-attached paths. Narrowed strip_quotes to the POSIX `--` test only, kept flag-skip on the raw token, and added explicit validation of attached path values (`-mPATH`, `--mode=PATH`).
+- **Replace `=/` heuristic with explicit write-target option white-list** (`00d7300`) — the prior heuristic treated *any* `--name=value` starting with `/` as a write target, producing false positives on read-only options that happen to take an absolute path. Replaced with an explicit white-list of rsync/install options that actually write.
+- **Add rsync batch-file write options to white-list** (`8141400`) — Codex flagged that `--write-batch=FILE` and `--only-write-batch=FILE` were missing from the white-list; both write to disk and now block when the target is outside the project.
+
+### Refactor
+
+- **`hooks/guard.sh` — decompose `check_single_command` into detector clusters** (#16, `6a7779e`). No behavior change; smaller functions per detector family make the next bypass closure easier to land surgically.
+- **`hooks/guard.sh` — extract tokenize / command_name / paths / heredoc modules** (#15, `38cdde0`).
+- **`tests/test_bypass_reproducers.sh` split into core + recent** (`c4a70e0`) — the file had grown past 1000 lines; splitting keeps the suite readable and lets new reproducers land without churning the whole file.
+
+### Tests
+
+- New reproducers across `tests/test_bypass_reproducers_recent.sh` for each of the 3 closures (each FAILED first, per the project TDD flow).
+- `tests/test_true_negatives.sh` extended with positive cases for legitimate flag-attached paths and quoted operands.
+- Full suite: **785 passed / 0 failed.**
+
+### Notes
+
+- All three closures follow `CLAUDE.md §Security-bypass TDD flow`: one bypass per commit, reproducer FAILS first, then the patch. Codex review on each commit drove the four hardening follow-ups above; each is its own commit so regression bisect stays clean.
+
 ## [1.7.0] — 2026-04-23
 
 ### Security — closes 3 bypass categories from Codex review on commit e01df86

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Hardening — Codex review follow-ups on the C-class fix
 
-- **Surgical flag-skip with quote-aware comparison + value validation** (`bb9e2c3`, `f76ec34`) — the broad strip_quotes pass over every token introduced a P2 false positive on legitimate flag-attached paths. Narrowed strip_quotes to the POSIX `--` test only, kept flag-skip on the raw token, and added explicit validation of attached path values (`-mPATH`, `--mode=PATH`).
+- **Surgical flag-skip with quote-aware comparison** (`bb9e2c3`, `f76ec34`) — the iteration on top of the C-class fix went through two extremes before settling: `ce011af` ran every flag test on the strip_quotes view (P1: quoted attached path-options like `"--target-directory=/tmp/out"` were also stripped of their `--` and treated as non-flags); `bb9e2c3` reverted the flag-skip to the raw token (P2: quoted plain flags like `"--help"` and `"--mode" 0755 src dst` were misread as pathname operands and blocked from outside cwd). The settled shape (`f76ec34`) keeps the strip_quotes view for both the `--` terminator test and the `-*` flag-skip, and routes attached `--name=PATH` values through path validation when (and only when) `name` is on the write-target white-list (see next bullet). Mode/owner/group VALUES are deliberately not path-validated — `--mode=`, `--owner=`, `--group=`, `-mPATH`, etc. are skipped as ordinary flags.
 - **Replace `=/` heuristic with explicit write-target option white-list** (`00d7300`) — the prior heuristic treated *any* `--name=value` starting with `/` as a write target, producing false positives on read-only options that happen to take an absolute path. Replaced with an explicit white-list of rsync/install options that actually write.
 - **Add rsync batch-file write options to white-list** (`8141400`) — Codex flagged that `--write-batch=FILE` and `--only-write-batch=FILE` were missing from the white-list; both write to disk and now block when the target is outside the project.
 
@@ -27,9 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Tests
 
-- New reproducers across `tests/test_bypass_reproducers_recent.sh` for each of the 3 closures (each FAILED first, per the project TDD flow).
+- New reproducers across `tests/test_bypass_reproducers_recent.sh` for each of the 3 closures (each FAILED first, per the project TDD flow). Section 27 added in the Copilot follow-up commit pins the attached-flag behavior contract (short / long / quoted forms for `-m`/`-o`/`-g`, and the explicit "no path-validation for mode/owner/group VALUES" rule) so future doc drift is caught by the suite, not just by review.
 - `tests/test_true_negatives.sh` extended with positive cases for legitimate flag-attached paths and quoted operands.
-- Full suite: **785 passed / 0 failed.**
+- `tests/test_bash_advanced.sh` §50 added documenting the `$VAR` / `${VAR}` fail-closed contract (BLOCKED: bare, braced, positional, special parameters; ALLOWED: `$HOME` passthrough, ANSI-C `$'…'`, i18n `$"…"`, backslash-escaped, single-quoted, quoted-heredoc body).
+- Full suite: **821 passed / 0 failed.**
 
 ### Notes
 

--- a/hooks/lib/detectors/write_targets.sh
+++ b/hooks/lib/detectors/write_targets.sh
@@ -72,8 +72,11 @@ run_write_target_detectors() {
       # the value when name is on the WHITE-LIST of options that
       # actually point at a write target — currently
       # `--target-directory=`. All other -* tokens (including
-      # `--exclude=`, `--rsync-path=`, `--mode=`, etc.) are skipped
-      # as flags. The white-list approach replaced an earlier
+      # `--mode=`, `--owner=`, `--group=`, etc.) are skipped as
+      # flags — their values aren't paths, and even when they
+      # syntactically look like one (e.g. `--mode=/0644`), they
+      # never become a write destination. The white-list approach
+      # replaced an earlier
       # `=*/*` heuristic that both missed relative values and
       # over-matched benign options carrying `/` (Codex review on
       # commit f76ec34, write_targets.sh:100 + 161).

--- a/hooks/session_hint.md
+++ b/hooks/session_hint.md
@@ -1,4 +1,4 @@
-[project-boundary] Guard blocks `$(...)` (fail-closed, uninspectable). For git commit with multiline body, ALWAYS use stdin heredoc:
+[project-boundary] Guard blocks `$(...)` AND `$VAR`/`${VAR}` operands (fail-closed, uninspectable; only `$HOME` is allowed). Inline literal values, or use Read/Grep tools instead of Bash piping with shell vars. For git commit with multiline body, ALWAYS use stdin heredoc:
   git commit -F - <<'EOF'
   <title>
 

--- a/tests/test_bash_advanced.sh
+++ b/tests/test_bash_advanced.sh
@@ -729,3 +729,54 @@ expect_blocked "pipe to bash -l" \
   'echo "cmd" | bash -l'
 
 echo ""
+
+# ============================================================
+# 50. Variable expansion is fail-closed (only $HOME allowed)
+#
+# The guard cannot inspect what `$P`, `${FILE}`, `$1`, `$@`, etc. resolve
+# to at exec time, so every non-HOME parameter expansion is refused with
+# the same fail-closed contract as `$(...)`. Documents the rule users
+# hit when they write `P=/path/to/file; grep X "$P"` style commands.
+# ============================================================
+echo "--- Variable expansion (fail-closed; only \$HOME allowed) ---"
+
+# BLOCKED — bare $VAR, ${VAR}, with attached/separated path forms
+expect_blocked "bare \$P operand"             'rm $P'
+expect_blocked "braced \${FILE} operand"      'cat ${FILE}'
+expect_blocked "\$VAR concatenated with path" 'rm $P/file'
+expect_blocked "\${VAR}/path concatenation"   'rm ${P}/file'
+expect_blocked "\$VAR inside double quotes"   'grep X "$P"'
+expect_blocked "\$VAR with underscore name"   'rm $foo_bar'
+expect_blocked "\$VAR as redirect target"     'echo x > $OUT'
+expect_blocked "\$VAR in for-loop body"       'for f in a b; do rm $f; done'
+
+# BLOCKED — positional and special parameters
+expect_blocked "positional \$1"               'rm $1'
+expect_blocked "special \$@"                  'rm $@'
+expect_blocked "special \$*"                  'rm $*'
+expect_blocked "special \$?"                  'echo $?'
+expect_blocked "special \$!"                  'echo $!'
+expect_blocked "special \$\$"                 'echo $$'
+expect_blocked "special \$#"                  'echo $#'
+
+# ALLOWED — $HOME passthrough (then resolved by expand_path)
+expect_allowed "bare \$HOME in echo"          'echo $HOME'
+expect_allowed "braced \${HOME} in echo"      'echo ${HOME}'
+
+# ALLOWED — non-expansion forms that share the $X prefix
+expect_allowed "ANSI-C quoted literal \$'...'"   "echo \$'literal\\n'"
+expect_allowed 'i18n quoted literal $"..."'      'echo $"some string"'
+
+# ALLOWED — literal $ (escaped or single-quoted)
+expect_allowed "backslash-escaped \\\$VAR"    'echo \$VAR'
+expect_allowed "single-quoted \$VAR"          "echo '\$VAR'"
+
+# ALLOWED — \$VAR inside a quoted heredoc body (body bytes blanked)
+expect_allowed "\$VAR inside quoted heredoc body" \
+  "git commit -F - <<'EOF'
+title
+
+body mentions \$VAR and \${FILE}
+EOF"
+
+echo ""

--- a/tests/test_bypass_reproducers_core.sh
+++ b/tests/test_bypass_reproducers_core.sh
@@ -8,11 +8,12 @@
 # corresponding reproducer is added FIRST and must FAIL until the fix
 # lands — see CLAUDE.md §Security-bypass TDD flow.
 #
-# Sections 16-23 (heredoc parser, multi-heredoc body ordering, quoted
+# Sections 16-27 (heredoc parser, multi-heredoc body ordering, quoted
 # command-name, /bin prefix in CMD_BLANKED, install / rsync walker
-# fixes, php attached form) live in test_bypass_reproducers_recent.sh.
-# Both files are sourced by test_guard.sh; the split keeps each file
-# under the 1000-line refactor threshold.
+# fixes, php attached form, attached-option white-list, attached-flag
+# behavior pinning) live in test_bypass_reproducers_recent.sh. Both
+# files are sourced by test_guard.sh; the split keeps each file under
+# the 1000-line refactor threshold.
 #
 # Sourced by test_guard.sh — requires helpers.sh loaded first.
 

--- a/tests/test_bypass_reproducers_recent.sh
+++ b/tests/test_bypass_reproducers_recent.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
-# Bypass reproducers (recent / sections 16-23) — heredoc parser,
+# Bypass reproducers (recent / sections 16-27) — heredoc parser,
 # multi-heredoc body ordering, quoted command-name, /bin prefix in
-# CMD_BLANKED, install / rsync walker fixes, php attached form.
+# CMD_BLANKED, install / rsync walker fixes (POSIX `--`, attached
+# write-target white-list, quoted-option normalization), php attached
+# form, attached-flag behavior pinning.
 # Continuation of test_bypass_reproducers_core.sh; same TDD discipline.
 #
 # Sourced by test_guard.sh — requires helpers.sh loaded first.
 
 echo "========================================"
-echo "  Bypass reproducers (recent, sections 16-23)"
+echo "  Bypass reproducers (recent, sections 16-27)"
 echo "  PROJECT_DIR=$PROJECT"
 echo "========================================"
 echo ""
@@ -596,12 +598,18 @@ echo ""
 # pathname (joined to EFFECTIVE_CWD, resolved, blocked by
 # is_inside_project).
 #
-# Fix: strip_quotes ONLY for the literal `--` terminator test;
-# the generic `-*` flag-skip stays on RAW TARGET so quoted
-# attached options fall through to path validation.
+# Fix (current shape after follow-ups): every flag test is run
+# on a strip_quotes view of the token (`*_tok`), so `"--help"`
+# behaves like `--help`, `"--"` behaves like `--`, and a quoted
+# attached option like `"--target-directory=/tmp/out"` reaches
+# the white-list match below and gets its value validated. The
+# raw token is no longer special-cased — the white-list (here)
+# and the explicit -m/-o/-g case (further down) decide which
+# tokens carry write-target values vs. ordinary skip-as-flag.
 #
 # Reported by Codex review on commit ce011af
-# (write_targets.sh:76-87 + 123-128).
+# (write_targets.sh:76-87 + 123-128); refined by f76ec34 and
+# narrowed to the white-list shape by 00d7300.
 # ============================================================
 echo "--- 25. quoted attached options must reach path validation ---"
 
@@ -636,14 +644,21 @@ echo ""
 # `--log-file=/tmp/log`, `--partial-dir=/tmp/p` regardless of
 # their value. The PATH portion was never validated.
 #
-# Note: also closes the BOTH the unquoted form (pre-existing
-# bypass not previously reproduced) and the quoted form (regression
-# would have been introduced by commit bb9e2c3).
+# Note: closes BOTH the unquoted form (pre-existing bypass not
+# previously reproduced) and the quoted form (regression that
+# would have been re-introduced by commit bb9e2c3).
 #
-# Fix shape: when the stripped token matches `-*` AND has form
-# `name=value` AND value contains `/`, extract the value and run
-# it through the same boundary check used for ordinary path
-# operands.
+# Fix shape (current, after Codex 00d7300): instead of a generic
+# "any `-*=value` with `/` in value" heuristic, the walkers carry
+# an explicit white-list of options that actually point at a write
+# target — for `install` it is `--target-directory=`; for `rsync`
+# it is `--log-file=`, `--partial-dir=`, `--backup-dir=`,
+# `--temp-dir=`, `--write-batch=`, `--only-write-batch=`. Only
+# values of those options are run through the boundary check;
+# every other attached option (`--exclude=`, `--rsync-path=`,
+# `--mode=`, `--owner=`, `--group=`, …) is skipped as a flag.
+# The earlier `=*/*` heuristic both missed relative values and
+# over-matched benign options carrying `/`.
 # ============================================================
 echo "--- 26. attached path-bearing options must be validated ---"
 
@@ -722,6 +737,100 @@ expect_blocked_cwd "rsync --only-write-batch=/tmp/batch src dst" \
 # --read-batch is a READ, not a write target — must remain ALLOWED:
 expect_allowed_cwd "rsync --read-batch=/tmp/batch src dst (read-only)" \
   "rsync --read-batch=/tmp/batch $PROJECT/CHANGELOG.md $PROJECT/tests/scratch.txt" \
+  "/tmp"
+
+echo ""
+
+# ============================================================
+# 27. Attached-flag forms: behavior pinning for install -m/-o/-g
+# ------------------------------------------------------------
+# Documents what the `install` walker actually does for the four
+# attached forms of mode/owner/group flags, so future doc drift
+# is caught by the test suite (and not just by Copilot review on
+# the next PR). No bypass exists in any of these shapes — the
+# tests pin the contract:
+#
+#   bare:                `-m`, `--mode`         → consume next token (skip_next)
+#   short attached:      `-m0644`               → ordinary flag, no skip
+#   long  attached:      `--mode=0644`          → ordinary flag, no skip
+#   white-listed attached: `--target-directory=`→ value validated
+#
+# Mode/owner/group VALUES are never validated as paths — even
+# when the value syntactically looks like one (`--mode=/0644`).
+# This deliberately differs from the f76ec34 `=*/*` heuristic
+# (replaced by 00d7300) and matches the install grammar: those
+# flags carry a mode bitmask / owner-name / group-name, not a
+# filesystem path.
+#
+# True positives (BLOCKED) — the destination operand AFTER an
+# attached flag is still validated against the project boundary.
+# False positives prevented (ALLOWED) — legitimate use of every
+# attached form must pass when the destination is in-project.
+# ============================================================
+echo "--- 27. attached-flag behavior pinning (install) ---"
+
+# True positives: outside-project destination after attached flag
+# must be BLOCKED on the destination, not on the flag itself.
+expect_blocked_cwd "install -m0644 OUTSIDE (short attached + outside dest)" \
+  "install -m0644 $PROJECT/CHANGELOG.md /tmp/install_target_t27" \
+  "/tmp"
+
+expect_blocked_cwd "install --mode=0644 OUTSIDE (long attached + outside dest)" \
+  "install --mode=0644 $PROJECT/CHANGELOG.md /tmp/install_target_t27" \
+  "/tmp"
+
+expect_blocked_cwd "install --owner=root OUTSIDE (long attached + outside dest)" \
+  "install --owner=root $PROJECT/CHANGELOG.md /tmp/install_target_t27" \
+  "/tmp"
+
+expect_blocked_cwd "install --group=wheel OUTSIDE (long attached + outside dest)" \
+  "install --group=wheel $PROJECT/CHANGELOG.md /tmp/install_target_t27" \
+  "/tmp"
+
+expect_blocked_cwd "install -m0644 -o root --group=wheel OUTSIDE (mixed attached)" \
+  "install -m0644 -o root --group=wheel $PROJECT/CHANGELOG.md /tmp/install_target_t27" \
+  "/tmp"
+
+# True positive: POSIX `--` after attached flags still routes the
+# trailing positional through path validation.
+expect_blocked_cwd "install -m0644 -- OUTSIDE (attached then --)" \
+  "install -m0644 -- $PROJECT/CHANGELOG.md /tmp/install_target_t27" \
+  "/tmp"
+
+# False positives prevented: in-project destination, every shape.
+expect_allowed "install -m0644 IN_PROJECT (short attached, in-project dest)" \
+  "install -m0644 $PROJECT/CHANGELOG.md $PROJECT/tests/scratch_t27.txt"
+
+expect_allowed "install --mode=0644 IN_PROJECT (long attached, in-project dest)" \
+  "install --mode=0644 $PROJECT/CHANGELOG.md $PROJECT/tests/scratch_t27.txt"
+
+expect_allowed "install -oroot IN_PROJECT (short attached owner)" \
+  "install -oroot $PROJECT/CHANGELOG.md $PROJECT/tests/scratch_t27.txt"
+
+expect_allowed "install -gwheel IN_PROJECT (short attached group)" \
+  "install -gwheel $PROJECT/CHANGELOG.md $PROJECT/tests/scratch_t27.txt"
+
+# False positives prevented: mode/owner/group VALUES that look
+# like paths must NOT trigger the boundary check — they aren't
+# write destinations. Pins the explicit "no path-validation for
+# -mPATH / --mode=PATH" contract that 00d7300 replaced the
+# earlier `=*/*` heuristic with.
+expect_allowed_cwd "install --mode=/0644 IN_PROJECT (path-shaped mode value, ignored)" \
+  "install --mode=/0644 $PROJECT/CHANGELOG.md $PROJECT/tests/scratch_t27.txt" \
+  "/tmp"
+
+expect_allowed_cwd "install --owner=user/group IN_PROJECT (slash in owner, ignored)" \
+  "install --owner=user/group $PROJECT/CHANGELOG.md $PROJECT/tests/scratch_t27.txt" \
+  "/tmp"
+
+# Quoted attached forms behave identically to unquoted (strip_quotes
+# normalizes before the flag tests):
+expect_blocked_cwd "install \"-m0644\" OUTSIDE (quoted short attached)" \
+  "install \"-m0644\" $PROJECT/CHANGELOG.md /tmp/install_target_t27" \
+  "/tmp"
+
+expect_allowed_cwd "install \"--mode=0644\" IN_PROJECT (quoted long attached)" \
+  "install \"--mode=0644\" $PROJECT/CHANGELOG.md $PROJECT/tests/scratch_t27.txt" \
   "/tmp"
 
 echo ""


### PR DESCRIPTION
## Summary

- Documents the dollar-prefixed-variable guard rule (bare and braced) in `session_hint.md` (was only mentioning command substitution; agents repeatedly burned 4-5 tool calls on `P=...; grep X "P-expanded"` style commands).
- Adds 22 test cases to `test_bash_advanced.sh` §50 covering `$VAR` / `${VAR}` BLOCKED forms (bare, braced, positional, special parameters) and ALLOWED forms (`HOME` passthrough, ANSI-C / i18n quoted literals, backslash-escaped, single-quoted, quoted-heredoc body) — pins the fail-closed contract that already existed in code.
- Adds 14 test cases in §27 of `test_bypass_reproducers_recent.sh` that pin attached-flag behavior for the install / rsync write-target white-list (BLOCKED outside-project destinations after `-m0644`, `--mode=`, `--owner=`, `--group=`, mixed attached, and after POSIX `--`; ALLOWED in-project destinations and path-shaped non-target values).
- Fixes doc drift flagged by Copilot review on PR #18 (CHANGELOG hardening bullets, `write_targets.sh` install-walker comment, `test_bypass_reproducers_*` section-range headers, §25/§26 narrative vs current implementation).
- Bumps `plugin.json` 1.7.0 to 1.8.0 with CHANGELOG entry; adds `.revive/` to `.gitignore`.

(The 3 install / rsync bypass closures and 4 hardening follow-ups themselves landed via squash-merge of #17.)

## Test plan

- [x] `bash tests/test_guard.sh` --- **821 passed / 0 failed** (was 785 on `main`; +22 from §50 variable-expansion, +14 from §27 attached-flag pinning)
- [x] `session_hint.md` size 534 / 800 bytes
- [ ] Manual sanity check after merge: `install` and `rsync` POSIX double-dash reproducers stay BLOCKED on `main`
- [ ] Tag `v1.8.0` and cut GitHub Release once merged
