### PR TITLE
Fix #21: remote-dispatch false positives (ssh/scp/docker/kubectl/...)

### DIFF
--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -37,6 +37,8 @@ source "$_GUARD_DIR/lib/detectors/destructive.sh"
 source "$_GUARD_DIR/lib/detectors/write_targets.sh"
 # shellcheck source=lib/options.sh
 source "$_GUARD_DIR/lib/options.sh"
+# shellcheck source=lib/remote_dispatch.sh
+source "$_GUARD_DIR/lib/remote_dispatch.sh"
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
@@ -851,6 +853,34 @@ check_single_command() {
       fi
     fi
   fi
+
+  # --- Neutralise remote-dispatch commands before path walkers run ---
+  # Issue #21. ssh / scp / docker exec / kubectl exec / etc. dispatch
+  # their operands to a remote host or foreign (container/namespace)
+  # filesystem. The boundary plugin protects the LOCAL filesystem, so
+  # those operands must be removed before the cp/tee/rm/redirect/...
+  # walkers run — otherwise a quoted remote command like
+  # `ssh host "docker cp /tmp/x container:/y"` produces a false-positive
+  # block on `/tmp/x` (the cp regex matches the literal ` cp ` inside
+  # the quoted argument). Policy checks earlier in this function
+  # (bash -c, $VAR, $(...), heredoc-fed-shell, script execution) MUST
+  # remain on the original CMD because those events happen LOCALLY,
+  # before ssh / docker ever see the argument string. The rewrite here
+  # only narrows what the path walkers see; CMD_TOKENS / CMD_BLANKED /
+  # CMD_TOKENS_SCAN are regenerated so every detector sees a consistent
+  # view. Generic for the whole class — see hooks/lib/remote_dispatch.sh.
+  CMD=$(rewrite_remote_dispatch "$CMD")
+  CMD_BLANKED=$(rewrite_remote_dispatch "$CMD_BLANKED")
+  CMD_TOKENS=()
+  while IFS= read -r tok; do
+    [[ -z "$tok" ]] && continue
+    CMD_TOKENS+=("$tok")
+  done < <(tokenize_args "$CMD")
+  CMD_TOKENS_SCAN=()
+  while IFS= read -r tok; do
+    [[ -z "$tok" ]] && continue
+    CMD_TOKENS_SCAN+=("$tok")
+  done < <(tokenize_args "$CMD_BLANKED")
 
   # xargs, find-delete, rm, mv, cp, ln moved to hooks/lib/detectors/destructive.sh.
   run_destructive_detectors

--- a/hooks/lib/remote_dispatch.sh
+++ b/hooks/lib/remote_dispatch.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# project-boundary guard — remote_dispatch module
+# ================================================
+# Generic neutralisation of "remote-dispatch" commands whose operands
+# target a remote host or a foreign (container/namespace) filesystem
+# rather than the local one this guard protects. Without this pass,
+# tokens that are part of a remote command string get walked by the
+# local-path detectors (cp, tee, rm, redirect, ...) and produce
+# false-positive boundary blocks.
+#
+# Three universal shapes are recognised, all rewritten so downstream
+# detectors only see the local-side surface (or nothing, when there
+# is no local surface):
+#
+#   1. Pure remote-fs tools  — every operand is remote/network.
+#        scp / rcp / sftp
+#      Rewrite: collapse CMD to the bare verb name.
+#
+#   2. Remote-command dispatch — `<verb> [opts] <target> <opaque-cmd>`,
+#      where the target is a host / container / pod / process and the
+#      trailing tokens form a command executed on that target.
+#        ssh / nsenter / chroot
+#        docker exec | docker run
+#        podman exec | podman run
+#        kubectl exec | oc exec | crictl exec
+#        lxc exec
+#      Rewrite: collapse CMD to the verb prefix only.
+#
+#   3. Remote file copy with mixed local / remote operands —
+#      `<verb> <subverb> <a> <b>` where one operand has the form
+#      `<id>:<path>` and the other is local.
+#        docker cp | podman cp | kubectl cp | oc cp
+#      Rewrite: keep the verb prefix and the LOCAL operand only;
+#      drop every operand that matches the `<id>:<path>` pattern.
+#
+# Depends on tokenize_args / strip_quotes from hooks/lib/tokenize.sh.
+# Pure (no caller-scope dependencies); returns the rewritten command
+# string on stdout.
+
+# --- Generic remote-target detector ---
+# Returns 0 iff the argument looks like a "remote address" of the
+# universal `<id>:<path>` form used by ssh, scp, rsync, docker cp,
+# kubectl cp, etc. The `:` must live in the FIRST path segment
+# (before any `/`) — a local path may legitimately contain `:` after a
+# slash (e.g. `../tmp/a:b`), and a URL like `http://...` keeps the
+# scheme separator inside the first segment but is excluded by an
+# explicit URL check first.
+_rd_is_remote_target_operand() {
+  local arg="$1"
+  case "$arg" in
+    *://*) return 1 ;;  # URL scheme
+  esac
+  local first="${arg%%/*}"
+  case "$first" in
+    *:*) return 0 ;;
+  esac
+  return 1
+}
+
+# --- Find command-name token index, skipping wrappers/flags/VAR=val ---
+# Mirrors the wrapper-skip rules used by strip_command_name_prefix and
+# command_name_is. Reads from the module-local _RD_TOKS array (set by
+# rewrite_remote_dispatch before calling). Returns -1 if no command-name
+# found. Uses a global rather than `local -n` because macOS ships
+# bash 3.2 which lacks nameref support.
+_rd_find_verb_idx() {
+  local i prev_was_timeout=0
+  for i in "${!_RD_TOKS[@]}"; do
+    local raw="${_RD_TOKS[$i]}" t
+    t=$(strip_quotes "$raw")
+    if [ $prev_was_timeout -eq 1 ]; then
+      prev_was_timeout=0
+      case "$t" in
+        [0-9]*) continue ;;
+      esac
+    fi
+    case "$t" in
+      timeout)
+        prev_was_timeout=1; continue ;;
+      sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
+        continue ;;
+    esac
+    case "$t" in
+      [A-Za-z_]*=*) continue ;;
+      -*) continue ;;
+    esac
+    printf '%d' "$i"
+    return
+  done
+  printf -- '-1'
+}
+
+# --- Strip a /bin/, /sbin/, /usr/bin/, /usr/sbin/, /usr/local/bin/ prefix ---
+_rd_strip_path_prefix() {
+  local n="$1"
+  case "$n" in
+    /bin/*|/sbin/*|/usr/bin/*|/usr/sbin/*|/usr/local/bin/*) printf '%s' "${n##*/}" ;;
+    *) printf '%s' "$n" ;;
+  esac
+}
+
+# --- Main entry: rewrite remote-dispatch commands ---
+# In:  full CMD string
+# Out: CMD string with remote portions removed; unchanged for non-dispatch verbs.
+rewrite_remote_dispatch() {
+  local cmd="$1"
+  _RD_TOKS=()
+  local t
+  while IFS= read -r t; do
+    [[ -z "$t" ]] && continue
+    _RD_TOKS+=("$t")
+  done < <(tokenize_args "$cmd")
+
+  local verb_idx
+  verb_idx=$(_rd_find_verb_idx)
+  [ "$verb_idx" -lt 0 ] && { printf '%s' "$cmd"; return; }
+
+  local verb subverb=""
+  verb=$(strip_quotes "${_RD_TOKS[$verb_idx]}")
+  verb=$(_rd_strip_path_prefix "$verb")
+  if [ $((verb_idx + 1)) -lt ${#_RD_TOKS[@]} ]; then
+    subverb=$(strip_quotes "${_RD_TOKS[$((verb_idx + 1))]}")
+  fi
+
+  # Class 1: pure remote-fs tools.
+  case "$verb" in
+    scp|rcp|sftp)
+      printf '%s' "$verb"
+      return ;;
+  esac
+
+  # Class 3: two-word remote copy verbs.
+  case "$verb $subverb" in
+    "docker cp"|"podman cp"|"kubectl cp"|"oc cp")
+      _rd_rewrite_remote_copy "$verb_idx"
+      return ;;
+  esac
+
+  # Class 2: two-word remote-command dispatch verbs.
+  case "$verb $subverb" in
+    "docker exec"|"docker run"|"podman exec"|"podman run"|"kubectl exec"|"oc exec"|"crictl exec"|"lxc exec"|"buildah run")
+      printf '%s %s' "$verb" "$subverb"
+      return ;;
+  esac
+
+  # Class 2: one-word remote-command dispatch verbs.
+  case "$verb" in
+    ssh|nsenter|chroot)
+      printf '%s' "$verb"
+      return ;;
+  esac
+
+  printf '%s' "$cmd"
+}
+
+# --- Rewrite a `<verb> <subverb> <operand-a> <operand-b>` copy invocation ---
+# Keep the verb pair plus operands that are NOT remote `<id>:<path>` form.
+# Flags are dropped (they cannot be local file targets in any of the
+# supported `cp` subcommands; -L, --follow-link, --archive etc. are
+# value-less or take non-path values).
+_rd_rewrite_remote_copy() {
+  local v_idx="$1"
+  local k=$((v_idx + 2)) n=${#_RD_TOKS[@]}
+  # Walk positional operands. cp-family semantics: the LAST positional
+  # is the destination, every prior one is a source. The plugin protects
+  # writes, not reads, so a local source is left out of the check
+  # (uploading `docker cp /tmp/x container:/y` is read-only on /tmp/x and
+  # must not false-positive). A local DESTINATION is preserved as a `cp`
+  # operand so the existing cp walker validates it (downloads such as
+  # `docker cp container:/x /etc/foo` should still be blocked). Operands
+  # of the universal `<id>:<path>` form are dropped — they target a
+  # foreign filesystem and the boundary doesn't apply.
+  local -a positionals=()
+  while [ $k -lt $n ]; do
+    local raw="${_RD_TOKS[$k]}" tok
+    tok=$(strip_quotes "$raw")
+    case "$tok" in
+      -*) k=$((k + 1)); continue ;;
+    esac
+    positionals+=("$raw")
+    k=$((k + 1))
+  done
+
+  local last_idx=$(( ${#positionals[@]} - 1 ))
+  if [ $last_idx -lt 0 ]; then
+    printf '%s %s' "${_RD_TOKS[$v_idx]}" "${_RD_TOKS[$((v_idx + 1))]}"
+    return
+  fi
+  local last_raw="${positionals[$last_idx]}"
+  local last_tok
+  last_tok=$(strip_quotes "$last_raw")
+  if _rd_is_remote_target_operand "$last_tok"; then
+    # Destination is remote → no local write surface. Collapse to verb pair
+    # so no walker fires on the local source(s).
+    printf '%s %s' "${_RD_TOKS[$v_idx]}" "${_RD_TOKS[$((v_idx + 1))]}"
+    return
+  fi
+  # Destination is local. Emit a synthetic `cp <dst>` so the cp walker
+  # in destructive.sh validates that single path. Source operands are
+  # dropped: remote ones are foreign, local ones are reads (not policed).
+  printf 'cp %s' "$last_raw"
+}

--- a/hooks/lib/remote_dispatch.sh
+++ b/hooks/lib/remote_dispatch.sh
@@ -121,6 +121,18 @@ _rd_strip_path_prefix() {
   esac
 }
 
+# --- Whitespace-list membership check ---
+# $1 = needle, $2 = space-separated haystack. Used to decide whether a
+# given short or long flag consumes the next token as its value.
+_rd_flag_takes_value() {
+  local needle="$1"
+  local short_list="$2"
+  local long_list="$3"
+  case " $short_list " in *" $needle "*) return 0 ;; esac
+  case " $long_list "  in *" $needle "*) return 0 ;; esac
+  return 1
+}
+
 # --- Main entry: rewrite remote-dispatch commands ---
 # In:  full CMD string
 # Out: CMD string with remote portions removed; unchanged for non-dispatch verbs.
@@ -186,22 +198,73 @@ rewrite_remote_dispatch() {
 # value-less or take non-path values).
 _rd_rewrite_remote_copy() {
   local v_idx="$1"
+  local verb_pair="${_RD_TOKS[$v_idx]} ${_RD_TOKS[$((v_idx + 1))]}"
   local k=$((v_idx + 2)) n=${#_RD_TOKS[@]}
+
+  # Per-verb flags-that-consume-the-next-token list. Necessary because
+  # Copilot review on PR #22 flagged a download-mode bypass shape:
+  #   `kubectl cp pod:/x /etc/owned --namespace default`
+  # without this table, `default` (the value of `--namespace`) gets
+  # added to the positionals list, becomes the LAST positional, and
+  # the rewrite emits `cp default` — relative path resolved inside
+  # the project → ALLOWED, missing the real download destination
+  # `/etc/owned`. cobra/pflag (used by kubectl/oc) lets flags appear
+  # before AND after positionals, so we can't just stop after the
+  # first non-flag token.
+  #
+  # docker cp / podman cp share a small flag set with no value-taking
+  # flags relevant to the path-walker bypass (`-a/--archive`,
+  # `-L/--follow-link`, `--quiet`, `--pause`, `--extract` are all
+  # value-less); their entries are deliberately empty. kubectl cp /
+  # oc cp inherit the entire kubectl global flag set — only the ones
+  # that take a value AND can credibly appear next to a path are
+  # listed here (kubeconfig/cluster paths can be local files but the
+  # plugin does not police reads, so we drop their values without
+  # validation).
+  local short_value_flags="" long_value_flags=""
+  case "$verb_pair" in
+    "kubectl cp"|"oc cp")
+      short_value_flags="-c -n -s"
+      long_value_flags="--container --namespace --kubeconfig --context --cluster --user --token --server --as --as-group --certificate-authority --client-certificate --client-key --cache-dir --request-timeout --tls-server-name --retries"
+      ;;
+  esac
+
   # Walk positional operands. cp-family semantics: the LAST positional
-  # is the destination, every prior one is a source. The plugin protects
-  # writes, not reads, so a local source is left out of the check
-  # (uploading `docker cp /tmp/x container:/y` is read-only on /tmp/x and
-  # must not false-positive). A local DESTINATION is preserved as a `cp`
-  # operand so the existing cp walker validates it (downloads such as
-  # `docker cp container:/x /etc/foo` should still be blocked). Operands
-  # of the universal `<id>:<path>` form are dropped — they target a
-  # foreign filesystem and the boundary doesn't apply.
+  # is the destination; every earlier positional is a source. The
+  # plugin protects writes, not reads — so a local SOURCE is dropped
+  # (uploading `docker cp /tmp/x container:/y` is read-only on /tmp/x
+  # and must not false-positive). A local DESTINATION is preserved
+  # below as the operand of a synthetic `cp <dst>` so the existing
+  # cp walker validates it. This is a deliberate divergence from the
+  # bare `cp` walker (which strict-checks both src and dst) — the
+  # remote-dispatch case has a remote operand on the OTHER side, so
+  # the boundary's "no copies from outside" semantics do not apply
+  # symmetrically here. Operands of the universal `<id>:<path>` form
+  # are dropped because they target a foreign filesystem.
   local -a positionals=()
   while [ $k -lt $n ]; do
     local raw="${_RD_TOKS[$k]}" tok
     tok=$(strip_quotes "$raw")
     case "$tok" in
-      -*) k=$((k + 1)); continue ;;
+      --)
+        # POSIX end-of-options: every later token is a positional,
+        # even if it begins with `-`. Used by kubectl exec but also
+        # valid for cp invocations.
+        k=$((k + 1))
+        while [ $k -lt $n ]; do
+          positionals+=("${_RD_TOKS[$k]}")
+          k=$((k + 1))
+        done
+        continue ;;
+      --*=*)
+        k=$((k + 1)); continue ;;
+      -*)
+        if _rd_flag_takes_value "$tok" "$short_value_flags" "$long_value_flags"; then
+          k=$((k + 2))
+        else
+          k=$((k + 1))
+        fi
+        continue ;;
     esac
     positionals+=("$raw")
     k=$((k + 1))
@@ -209,7 +272,7 @@ _rd_rewrite_remote_copy() {
 
   local last_idx=$(( ${#positionals[@]} - 1 ))
   if [ $last_idx -lt 0 ]; then
-    printf '%s %s' "${_RD_TOKS[$v_idx]}" "${_RD_TOKS[$((v_idx + 1))]}"
+    printf '%s' "$verb_pair"
     return
   fi
   local last_raw="${positionals[$last_idx]}"

--- a/hooks/lib/remote_dispatch.sh
+++ b/hooks/lib/remote_dispatch.sh
@@ -12,26 +12,48 @@
 # detectors only see the local-side surface (or nothing, when there
 # is no local surface):
 #
-#   1. Pure remote-fs tools  — every operand is remote/network.
+#   1. Network-copy tools — operate on a remote target but may also
+#      take local operands and -flag values. The point of this class
+#      is that the remote `host:/path` / `host::module` / `rsync://`
+#      operands must NOT be walked as local filesystem paths;
+#      legitimate local operands (`scp ./key host:/dst` etc.) are
+#      reads from the plugin's perspective and the boundary doesn't
+#      police those.
 #        scp / rcp / sftp
 #      Rewrite: collapse CMD to the bare verb name.
 #
 #   2. Remote-command dispatch — `<verb> [opts] <target> <opaque-cmd>`,
-#      where the target is a host / container / pod / process and the
-#      trailing tokens form a command executed on that target.
-#        ssh / nsenter / chroot
-#        docker exec | docker run
-#        podman exec | podman run
-#        kubectl exec | oc exec | crictl exec
-#        lxc exec
+#      where the target is a host / container / pod and the trailing
+#      tokens form a command executed on a foreign filesystem (NOT
+#      the local one this guard protects):
+#        ssh
+#        docker exec | podman exec
+#        kubectl exec | oc exec | crictl exec | lxc exec
 #      Rewrite: collapse CMD to the verb prefix only.
+#
+#      `nsenter` and `chroot` are deliberately EXCLUDED — they
+#      execute on the local host (just under a different namespace
+#      or apparent root), so their command operands can still touch
+#      host paths outside the project and must remain subject to the
+#      destructive walkers (Copilot review on PR #22).
+#
+#      `docker run` / `podman run` / `buildah run` are also EXCLUDED
+#      because the `-v src:dst` / `--volume` / `--mount type=bind,…`
+#      flags can bind-mount host paths into the container, turning a
+#      container-side write into a host-fs write that bypasses the
+#      boundary. Until host-mount-source parsing is added, leaving
+#      them subject to the existing walkers errs on the safe side
+#      (Copilot review on PR #22).
 #
 #   3. Remote file copy with mixed local / remote operands —
 #      `<verb> <subverb> <a> <b>` where one operand has the form
 #      `<id>:<path>` and the other is local.
 #        docker cp | podman cp | kubectl cp | oc cp
-#      Rewrite: keep the verb prefix and the LOCAL operand only;
-#      drop every operand that matches the `<id>:<path>` pattern.
+#      Rewrite: keep only the LOCAL DESTINATION operand (last
+#      positional, when not remote-shaped) so the cp walker still
+#      validates download targets like `… c:/x /etc/owned`. Source
+#      operands are dropped — local source = read (not policed),
+#      remote source = foreign filesystem.
 #
 # Depends on tokenize_args / strip_quotes from hooks/lib/tokenize.sh.
 # Pure (no caller-scope dependencies); returns the rewritten command
@@ -136,16 +158,20 @@ rewrite_remote_dispatch() {
       return ;;
   esac
 
-  # Class 2: two-word remote-command dispatch verbs.
+  # Class 2: two-word remote-command dispatch verbs. `docker run` /
+  # `podman run` / `buildah run` are intentionally NOT in this list —
+  # see the header comment for the bind-mount rationale.
   case "$verb $subverb" in
-    "docker exec"|"docker run"|"podman exec"|"podman run"|"kubectl exec"|"oc exec"|"crictl exec"|"lxc exec"|"buildah run")
+    "docker exec"|"podman exec"|"kubectl exec"|"oc exec"|"crictl exec"|"lxc exec")
       printf '%s %s' "$verb" "$subverb"
       return ;;
   esac
 
-  # Class 2: one-word remote-command dispatch verbs.
+  # Class 2: one-word remote-command dispatch verbs. `nsenter` and
+  # `chroot` are intentionally NOT in this list — see the header
+  # comment for why they remain subject to the local walkers.
   case "$verb" in
-    ssh|nsenter|chroot)
+    ssh)
       printf '%s' "$verb"
       return ;;
   esac

--- a/tests/test_true_negatives.sh
+++ b/tests/test_true_negatives.sh
@@ -855,4 +855,34 @@ expect_blocked "kubectl cp download to /etc destination" \
 expect_blocked "podman cp download to outside-project destination" \
   "podman cp mycontainer:/tmp/x /private/tmp/outside.md"
 
+# Lock: kubectl/oc cp flags-with-value can appear AFTER the positionals
+# (cobra/pflag allows this). Without per-verb flag-value awareness, the
+# flag's value would shadow the real destination and the rewrite would
+# emit `cp <flag-value>` (often a relative name resolving inside the
+# project). The walker must consume `--namespace default`, `-c name`,
+# `--kubeconfig <path>`, etc. as a single flag+value pair so the real
+# local destination still gets validated. (Copilot review on PR #22.)
+expect_blocked "kubectl cp download with trailing --namespace default" \
+  "kubectl cp mypod:/tmp/x /etc/owned --namespace default"
+
+expect_blocked "kubectl cp download with leading --namespace default" \
+  "kubectl cp --namespace default mypod:/tmp/x /etc/owned"
+
+expect_blocked "kubectl cp download with trailing --namespace=default attached" \
+  "kubectl cp mypod:/tmp/x /etc/owned --namespace=default"
+
+expect_blocked "kubectl cp download with -n short flag" \
+  "kubectl cp mypod:/tmp/x /etc/owned -n default"
+
+expect_blocked "kubectl cp download with -c container flag" \
+  "kubectl cp mypod:/tmp/x /etc/owned -c app"
+
+expect_blocked "oc cp download with trailing --namespace default" \
+  "oc cp mypod:/tmp/x /etc/owned --namespace default"
+
+# Lock for the upload side: same flag layout must NOT trip a false
+# positive on the local source.
+expect_allowed "kubectl cp upload with trailing --namespace default" \
+  "kubectl cp /tmp/x.md mypod:/data/x.md --namespace default"
+
 echo ""

--- a/tests/test_true_negatives.sh
+++ b/tests/test_true_negatives.sh
@@ -788,11 +788,16 @@ expect_allowed "docker exec running tee inside container" \
 expect_allowed "podman exec running mv inside container" \
   "podman exec mycontainer mv /etc/a /etc/b"
 
-# E) docker/podman run — opaque after image.
-expect_allowed "docker run with rm inside" \
+# E) docker / podman run — NOT collapsed (bind mounts can surface host
+# paths into the container; collapsing would let `-v /tmp:/data alpine
+# tee /data/x.md` write to host /tmp without a boundary check). The
+# existing walkers fire — false positives on no-mount runs are
+# accepted as the conservative default until mount-source parsing
+# lands. (Copilot review on PR #22.)
+expect_blocked "docker run rm inside container — blocked (no host-mount parser yet)" \
   "docker run --rm alpine rm -rf /var/cache"
 
-expect_allowed "docker run with bind mount and tee inside" \
+expect_blocked "docker run with bind mount writing to host via container path" \
   "docker run --rm -v /tmp:/data alpine tee /data/x.md"
 
 # F) kubectl exec / oc exec — opaque after pod and after `--`.
@@ -805,12 +810,19 @@ expect_allowed "kubectl exec -c container rm" \
 expect_allowed "oc exec rm inside pod" \
   "oc exec mypod -- rm -rf /var/cache"
 
-# G) lxc exec / nsenter / chroot — opaque after target.
+# G) lxc exec — opaque after container (foreign fs).
 expect_allowed "lxc exec rm" \
   "lxc exec mycontainer -- rm -rf /var/cache"
 
-expect_allowed "nsenter into pid running rm" \
+# nsenter / chroot execute on the LOCAL host (different namespace /
+# apparent root) — the inner command can still touch host paths
+# outside the project, so they are NOT in the dispatch list and the
+# rm walker stays in effect. (Copilot review on PR #22.)
+expect_blocked "nsenter rm — local host, walker stays in effect" \
   "nsenter -t 1234 -m -u -n rm -rf /tmp/foo"
+
+expect_blocked "chroot rm — local host, walker stays in effect" \
+  "chroot /mnt/sysimage rm -rf /etc/foo"
 
 # Lock: remote-dispatch ONLY blanks remote portion. The LOCAL prefix of a
 # chained command must still get a strict check. These verify the patch

--- a/tests/test_true_negatives.sh
+++ b/tests/test_true_negatives.sh
@@ -726,3 +726,121 @@ expect_blocked "live python -c on command line" \
   "python -c 'print(1)'"
 
 echo ""
+echo "--- Remote-dispatch class: arguments target a remote/foreign filesystem ---"
+# Issue #21. The boundary plugin protects the LOCAL filesystem; commands that
+# dispatch their operands to a remote host or container filesystem must not
+# trip the local-path walkers. Generic shape: a verb (or two-word verb) marks
+# the operands as remote, and the local-side surface (if any) is the only
+# part the guard validates.
+
+# A) Pure remote-fs tools — every operand is remote.
+expect_allowed "scp upload to host:/path" \
+  "scp ./local.md ragnarok:/tmp/draft.md"
+
+expect_allowed "scp download from host:/path to local cwd" \
+  "scp ragnarok:/tmp/draft.md ."
+
+expect_allowed "scp -i key upload" \
+  "scp -i ~/.ssh/id_ed25519 ./local.md user@ragnarok:/tmp/draft.md"
+
+expect_allowed "rcp upload" \
+  "rcp ./local.md ragnarok:/tmp/draft.md"
+
+expect_allowed "sftp batch put" \
+  "sftp -b /tmp/batch.txt user@ragnarok"
+
+# B) ssh with quoted remote command — opaque after host.
+expect_allowed "ssh + quoted docker cp inside" \
+  "ssh ragnarok \"docker cp /tmp/draft.md container:/tmp/\""
+
+expect_allowed "ssh + quoted chained remote commands" \
+  "ssh ragnarok \"docker cp /tmp/x.md c:/tmp/ && docker exec c bin/rails runner /tmp/x.rb\""
+
+expect_allowed "ssh + remote rm of /etc/x (remote fs, not local)" \
+  "ssh user@host \"rm -rf /etc/old\""
+
+expect_allowed "ssh + remote tee to /var/log" \
+  "ssh user@host \"tee /var/log/app.log\""
+
+# C) docker cp host<->container — only the local operand is checked.
+expect_allowed "docker cp local-to-container" \
+  "docker cp /tmp/draft.md container_id:/tmp/draft.md"
+
+expect_allowed "docker cp container-to-local cwd" \
+  "docker cp container_id:/tmp/x.log ."
+
+expect_allowed "podman cp local-to-container" \
+  "podman cp /tmp/x.md mycontainer:/data/x.md"
+
+expect_allowed "kubectl cp local-to-pod" \
+  "kubectl cp /tmp/x.md mypod:/data/x.md"
+
+expect_allowed "kubectl cp pod-to-local cwd" \
+  "kubectl cp mypod:/data/x.md ."
+
+# D) docker/podman exec — opaque after container id.
+expect_allowed "docker exec running rm on container fs" \
+  "docker exec container_id rm -rf /var/cache"
+
+expect_allowed "docker exec running tee inside container" \
+  "docker exec -i container_id tee /etc/app.conf"
+
+expect_allowed "podman exec running mv inside container" \
+  "podman exec mycontainer mv /etc/a /etc/b"
+
+# E) docker/podman run — opaque after image.
+expect_allowed "docker run with rm inside" \
+  "docker run --rm alpine rm -rf /var/cache"
+
+expect_allowed "docker run with bind mount and tee inside" \
+  "docker run --rm -v /tmp:/data alpine tee /data/x.md"
+
+# F) kubectl exec / oc exec — opaque after pod and after `--`.
+expect_allowed "kubectl exec rm inside pod" \
+  "kubectl exec mypod -- rm -rf /var/cache"
+
+expect_allowed "kubectl exec -c container rm" \
+  "kubectl exec mypod -c app -- rm -rf /tmp/x"
+
+expect_allowed "oc exec rm inside pod" \
+  "oc exec mypod -- rm -rf /var/cache"
+
+# G) lxc exec / nsenter / chroot — opaque after target.
+expect_allowed "lxc exec rm" \
+  "lxc exec mycontainer -- rm -rf /var/cache"
+
+expect_allowed "nsenter into pid running rm" \
+  "nsenter -t 1234 -m -u -n rm -rf /tmp/foo"
+
+# Lock: remote-dispatch ONLY blanks remote portion. The LOCAL prefix of a
+# chained command must still get a strict check. These verify the patch
+# does not over-relax destructive ops.
+expect_blocked "scp before destructive local rm /etc — local rm still blocked" \
+  "scp ./x ragnarok:/tmp/x && rm -rf /etc/foo"
+
+expect_blocked "ssh before destructive local rm /etc — local rm still blocked" \
+  "ssh host \"echo hi\" && rm -rf /etc/foo"
+
+expect_blocked "docker exec before destructive local rm /etc" \
+  "docker exec c ls && rm -rf /etc/foo"
+
+# Lock: bare names that COINCIDE with remote-dispatch verbs but lack the
+# dispatch shape (no quoted remote-cmd, no container operand) are still
+# subject to the normal walkers — we only relax when the dispatch shape
+# is unambiguous.
+expect_blocked "ssh-shaped local cp via cp command-name still blocked" \
+  "cp /etc/passwd $PROJECT/leak"
+
+# Lock: docker cp / kubectl cp DOWNLOAD mode — local destination outside
+# project must still be blocked. The remote_dispatch rewrite preserves
+# the local-side dst operand for the cp walker so this case stays caught.
+expect_blocked "docker cp download to /etc destination" \
+  "docker cp container_id:/tmp/x /etc/owned"
+
+expect_blocked "kubectl cp download to /etc destination" \
+  "kubectl cp mypod:/tmp/x /etc/owned"
+
+expect_blocked "podman cp download to outside-project destination" \
+  "podman cp mycontainer:/tmp/x /private/tmp/outside.md"
+
+echo ""


### PR DESCRIPTION
## Summary

- Fixes #21. Adds `hooks/lib/remote_dispatch.sh` and wires it into `check_single_command` so remote-dispatch commands (`ssh`, `scp`, `docker exec | cp | run`, `podman exec | cp`, `kubectl exec | cp`, `oc exec`, `lxc exec`, `nsenter`, `chroot`, …) no longer false-positive on the local-path walkers.
- Three universal shapes covered: pure remote-fs tools collapse to the bare verb; remote-command dispatch collapses to the verb prefix (target + opaque cmd dropped); remote file copy keeps only a LOCAL destination operand so download mode (`docker cp container:/x /etc/owned`) still gets caught by the cp walker.
- Policy checks (`bash -c`, `$VAR`, `$(...)`, heredoc-fed shell, script execution) keep running on the ORIGINAL CMD — they fire LOCALLY before ssh / docker ever see the argument string.

## Test plan

- [x] 865 / 865 green (`bash tests/test_guard.sh`); was 834 before. 28 new true-negatives + 4 lock tests added in `tests/test_true_negatives.sh`.
- [x] Lock: `scp ./x remote-host:/tmp/x && rm -rf /etc/foo` — second sub-command still BLOCKED.
- [x] Lock: `ssh host "echo hi" && rm -rf /etc/foo` — second sub-command still BLOCKED.
- [x] Lock: `docker cp container:/x /etc/owned` (download to outside project) — BLOCKED via cp walker on the synthetic `cp /etc/owned` rewrite.
- [x] Lock: `podman cp mycontainer:/tmp/x /private/tmp/outside.md` — BLOCKED.
- [x] Lock: bare `cp /etc/passwd $PROJECT/leak` (no remote-dispatch shape) — still BLOCKED.

Version stays at 1.8.0 — waiting on Copilot review before bumping.

