### PR TITLE
fix: arg-as-cmd flag-value bypasses (tar/rsync/git -c)

### DIFF
--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -884,6 +884,18 @@ check_single_command() {
     CMD_TOKENS_SCAN+=("$tok")
   done < <(tokenize_args "$CMD_BLANKED")
 
+  # --- Validate argument-as-command flag values recursively ---
+  # Tools like `tar --to-command=<cmd>` / `rsync -e <cmd>` /
+  # `git -c <exec-key>=<cmd>` execute the flag value as a local shell
+  # command. The walkers below only see flag NAMES — not VALUES — so a
+  # destructive payload would slip past them. Extract every recognised
+  # payload from this (post-split) subcommand and dispatch it through
+  # check_single_command recursively, reusing the entire detector
+  # pipeline. Generic for the whole class — see hooks/lib/subcmd_flags.sh.
+  while IFS= read -r _sf_payload; do
+    [ -n "$_sf_payload" ] && check_single_command "$_sf_payload"
+  done < <(extract_subcmd_flag_payloads "$CMD")
+
   # xargs, find-delete, rm, mv, cp, ln moved to hooks/lib/detectors/destructive.sh.
   run_destructive_detectors
 

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -39,6 +39,8 @@ source "$_GUARD_DIR/lib/detectors/write_targets.sh"
 source "$_GUARD_DIR/lib/options.sh"
 # shellcheck source=lib/remote_dispatch.sh
 source "$_GUARD_DIR/lib/remote_dispatch.sh"
+# shellcheck source=lib/subcmd_flags.sh
+source "$_GUARD_DIR/lib/subcmd_flags.sh"
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -220,6 +220,15 @@ check_single_command() {
     return 0
   fi
 
+  # Snapshot the command BEFORE sudo-strip and any other normalization,
+  # so extract_subcmd_flag_payloads can see the wrapper and its option-
+  # with-value flags (e.g. `sudo -u root tar --to-command='<payload>'`).
+  # The literal sudo-strip below removes only the bare `sudo ` token,
+  # leaving `-u root` behind — which would mis-identify the verb in
+  # the subcmd-flag scan. Reported by Copilot review on PR #23
+  # (guard.sh:897).
+  local _CMD_PRE_STRIP="$CMD"
+
   # --- Strip sudo prefix ---
   if [[ "$CMD" =~ ^sudo[[:space:]]+ ]]; then
     CMD="${CMD#sudo }"
@@ -892,9 +901,10 @@ check_single_command() {
   # payload from this (post-split) subcommand and dispatch it through
   # check_single_command recursively, reusing the entire detector
   # pipeline. Generic for the whole class — see hooks/lib/subcmd_flags.sh.
+  local _sf_payload
   while IFS= read -r _sf_payload; do
     [ -n "$_sf_payload" ] && check_single_command "$_sf_payload"
-  done < <(extract_subcmd_flag_payloads "$CMD")
+  done < <(extract_subcmd_flag_payloads "$_CMD_PRE_STRIP")
 
   # xargs, find-delete, rm, mv, cp, ln moved to hooks/lib/detectors/destructive.sh.
   run_destructive_detectors

--- a/hooks/lib/options.sh
+++ b/hooks/lib/options.sh
@@ -81,15 +81,6 @@ split_and_check() {
   local full_cmd="$1"
   export _GUARD_CD_OUTSIDE=0
   export _GUARD_CD_IN_ALLOWLIST=0
-
-  # --- Re-emit argument-as-command flag values as sibling statements ---
-  # Tools like `tar --to-command=<cmd>` execute their flag value as a
-  # local shell command, but the path / destructive walkers downstream
-  # only see flag NAMES — not VALUES. expand_subcmd_flags appends each
-  # such value after a `;` so the splitter below picks it up as an
-  # ordinary sub-command and routes it through check_single_command.
-  # Generic for the whole class — see hooks/lib/subcmd_flags.sh.
-  full_cmd=$(expand_subcmd_flags "$full_cmd")
   local -a subcmds=()
   local current=""
   local in_single_quote=0

--- a/hooks/lib/options.sh
+++ b/hooks/lib/options.sh
@@ -81,6 +81,15 @@ split_and_check() {
   local full_cmd="$1"
   export _GUARD_CD_OUTSIDE=0
   export _GUARD_CD_IN_ALLOWLIST=0
+
+  # --- Re-emit argument-as-command flag values as sibling statements ---
+  # Tools like `tar --to-command=<cmd>` execute their flag value as a
+  # local shell command, but the path / destructive walkers downstream
+  # only see flag NAMES — not VALUES. expand_subcmd_flags appends each
+  # such value after a `;` so the splitter below picks it up as an
+  # ordinary sub-command and routes it through check_single_command.
+  # Generic for the whole class — see hooks/lib/subcmd_flags.sh.
+  full_cmd=$(expand_subcmd_flags "$full_cmd")
   local -a subcmds=()
   local current=""
   local in_single_quote=0

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -66,31 +66,69 @@ declare -a SUBCMD_FLAG_SINKS=(
   "git|-c||git-config|^(core\\.(sshCommand|editor|pager|askPass|fsmonitor)|pager\\..+|sequence\\.editor|gpg\\.(program|ssh\\.program|openpgp\\.program|x509\\.program)|credential\\.helper|diff\\.(external|.+\\.(command|textconv))|mergetool\\..+\\.cmd|merge\\..+\\.driver|filter\\..+\\.(clean|smudge|process)|uploadpack\\.packObjectsHook|submodule\\..+\\.update|alias\\..+)$"
 )
 
+# --- Per-wrapper list of options that consume the NEXT token ---
+# Some wrappers take option-with-value flags before the real verb
+# (`sudo -u root cmd`, `env -u VAR cmd`, `timeout -k 5 10 cmd`).
+# Without skipping the value too, the verb-finder mis-identifies the
+# value as the verb (e.g. `root` instead of `cmd`), so the sink
+# table never matches. Reported by Copilot review on PR #23
+# (guard.sh:897). Returns a space-separated list on stdout; empty
+# for unknown wrappers.
+_sf_wrapper_opts_with_val() {
+  case "$1" in
+    sudo) printf -- '-u -g -p -h -D -C -A -K -k -r -t' ;;
+    env)  printf -- '-u -C -P --unset --chdir' ;;
+    timeout) printf -- '-k -s --kill-after --signal' ;;
+    nice) printf -- '-n --adjustment' ;;
+    ionice) printf -- '-c -n -p --class --classdata --pid' ;;
+    chrt) printf -- '-p --pid' ;;
+    *) ;;
+  esac
+}
+
 # --- Find verb token index, skipping wrappers / VAR=val / flags ---
 # Mirrors _rd_find_verb_idx in remote_dispatch.sh. Reads from the
-# module-local _SF_TOKS array (set by expand_subcmd_flags before
-# calling). Uses a global rather than `local -n` because macOS ships
-# bash 3.2 which lacks nameref support.
+# module-local _SF_TOKS array. Uses a global rather than `local -n`
+# because macOS ships bash 3.2 which lacks nameref support.
 _sf_find_verb_idx() {
-  local i prev_was_timeout=0
-  for i in "${!_SF_TOKS[@]}"; do
+  local i=0 n=${#_SF_TOKS[@]}
+  local prev_was_timeout=0 last_wrapper=""
+  while [ $i -lt $n ]; do
     local raw="${_SF_TOKS[$i]}" t
     t=$(strip_quotes "$raw")
+
+    # Wrapper opt-with-value: if the previous wrapper had options
+    # that consume the next token, advance past both the flag and
+    # its value (Copilot review on PR #23, guard.sh:897).
+    if [ -n "$last_wrapper" ]; then
+      local opts; opts=$(_sf_wrapper_opts_with_val "$last_wrapper")
+      if [ -n "$opts" ]; then
+        case " $opts " in
+          *" $t "*) i=$((i + 2)); continue ;;
+        esac
+      fi
+    fi
+
+    # `timeout` takes a duration operand (e.g. `timeout 5 cmd`,
+    # `timeout 1.5s cmd`, `timeout infinity cmd`); skip one extra
+    # token after it. Digit-prefixed forms cover `5`, `5s`, `2m`,
+    # `1.5h`; `inf*` covers `inf` / `infinity`.
     if [ $prev_was_timeout -eq 1 ]; then
       prev_was_timeout=0
       case "$t" in
-        [0-9]*) continue ;;
+        [0-9]*|inf*) i=$((i + 1)); continue ;;
       esac
     fi
     case "$t" in
       timeout)
-        prev_was_timeout=1; continue ;;
+        prev_was_timeout=1; last_wrapper="timeout"; i=$((i + 1)); continue ;;
       sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
-        continue ;;
+        last_wrapper=$(_sf_strip_path_prefix "$t")
+        i=$((i + 1)); continue ;;
     esac
     case "$t" in
-      [A-Za-z_]*=*) continue ;;
-      -*) continue ;;
+      [A-Za-z_]*=*) i=$((i + 1)); continue ;;
+      -*) i=$((i + 1)); continue ;;
     esac
     printf '%d' "$i"
     return

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# project-boundary guard — subcmd_flags module
+# =============================================
+# Some tools take a SHELL COMMAND as the value of a specific flag and
+# execute it locally at runtime. The guard's path / destructive walkers
+# only see flag NAMES — not flag VALUES — so a destructive command
+# hidden in such a value slips past every detector. Same side-channel
+# class as `find -exec <cmd>` (already covered) and the remote-dispatch
+# verbs from issue #21 (ssh / docker exec / kubectl exec): an opaque
+# command argument that the surface walker never opens.
+#
+# Affected sinks (added incrementally per the §Security-bypass TDD flow
+# in CLAUDE.md):
+#
+#   tar -xf … --to-command=<cmd>          [section 29]
+#
+# The rewrite is intentionally simple: pull each sub-command value out
+# of the original command string and re-emit it as a sibling statement
+# joined by `;`. The downstream split_and_check splitter picks the new
+# statement up automatically and dispatches it through the normal
+# check_single_command pipeline — so every existing destructive /
+# write-target walker validates the payload without any per-tool
+# duplication of detection logic.
+#
+#   tar -xf foo.tar --to-command='rm /etc/x'
+#     → tar -xf foo.tar --to-command='rm /etc/x' ; rm /etc/x
+#
+# The original verb invocation is preserved verbatim. The walkers
+# already ignore the literal `rm /etc/x` bytes inside the quoted
+# `--to-command=` value (they only match command names at token-start
+# positions, not inside a single arg token), so the original side of
+# the rewrite produces no extra detector hits — only the appended
+# sibling statement is validated as a real command.
+#
+# Pure (no caller-scope dependencies); returns the rewritten command
+# string on stdout. Depends on hooks/lib/tokenize.sh (tokenize_args,
+# strip_quotes).
+
+# --- Sink table ---
+# Format: "<verb>|<short_flag>|<long_flag_no_eq>|<kind>|<key_regex>"
+#
+#   verb         - command-name token after wrapper-skip
+#   short_flag   - short option that consumes the next token (e.g. "-e");
+#                  empty if none. Attached form `-eVALUE` also recognised.
+#   long_flag    - long option without trailing `=` (e.g. "--to-command");
+#                  empty if none. Both `--flag=VALUE` and `--flag VALUE`
+#                  shapes are recognised.
+#   kind         - "value":     value IS the shell command directly.
+#                  "git-config": value is `key=cmd`; only the rows whose
+#                                key matches <key_regex> are exec sinks.
+#   key_regex    - bash extended regex; used only when kind=git-config.
+declare -a SUBCMD_FLAG_SINKS=(
+  "tar||--to-command|value|"
+)
+
+# --- Find verb token index, skipping wrappers / VAR=val / flags ---
+# Mirrors _rd_find_verb_idx in remote_dispatch.sh. Reads from the
+# module-local _SF_TOKS array (set by expand_subcmd_flags before
+# calling). Uses a global rather than `local -n` because macOS ships
+# bash 3.2 which lacks nameref support.
+_sf_find_verb_idx() {
+  local i prev_was_timeout=0
+  for i in "${!_SF_TOKS[@]}"; do
+    local raw="${_SF_TOKS[$i]}" t
+    t=$(strip_quotes "$raw")
+    if [ $prev_was_timeout -eq 1 ]; then
+      prev_was_timeout=0
+      case "$t" in
+        [0-9]*) continue ;;
+      esac
+    fi
+    case "$t" in
+      timeout)
+        prev_was_timeout=1; continue ;;
+      sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
+        continue ;;
+    esac
+    case "$t" in
+      [A-Za-z_]*=*) continue ;;
+      -*) continue ;;
+    esac
+    printf '%d' "$i"
+    return
+  done
+  printf -- '-1'
+}
+
+# --- Strip /bin/, /sbin/, /usr/bin/, /usr/sbin/, /usr/local/bin/ prefix ---
+_sf_strip_path_prefix() {
+  local n="$1"
+  case "$n" in
+    /bin/*|/sbin/*|/usr/bin/*|/usr/sbin/*|/usr/local/bin/*) printf '%s' "${n##*/}" ;;
+    *) printf '%s' "$n" ;;
+  esac
+}
+
+# --- Main entry: append sub-command values as sibling statements ---
+# In:  full CMD string
+# Out: CMD string with each recognised flag-value re-emitted after a
+#      `;` separator; unchanged when no sink row matches the verb or
+#      when no recognised flag carries a value.
+expand_subcmd_flags() {
+  local cmd="$1"
+  _SF_TOKS=()
+  local t
+  while IFS= read -r t; do
+    [[ -z "$t" ]] && continue
+    _SF_TOKS+=("$t")
+  done < <(tokenize_args "$cmd")
+
+  local verb_idx
+  verb_idx=$(_sf_find_verb_idx)
+  [ "$verb_idx" -lt 0 ] && { printf '%s' "$cmd"; return; }
+
+  local verb
+  verb=$(strip_quotes "${_SF_TOKS[$verb_idx]}")
+  verb=$(_sf_strip_path_prefix "$verb")
+
+  # Match a sink row by verb. First match wins; the table currently
+  # has at most one row per verb.
+  local row sink_short="" sink_long="" sink_kind="" sink_key_regex=""
+  local matched=0
+  for row in "${SUBCMD_FLAG_SINKS[@]}"; do
+    local r_verb="${row%%|*}"
+    if [ "$r_verb" = "$verb" ]; then
+      local rest="${row#*|}"
+      sink_short="${rest%%|*}"; rest="${rest#*|}"
+      sink_long="${rest%%|*}"; rest="${rest#*|}"
+      sink_kind="${rest%%|*}"; rest="${rest#*|}"
+      sink_key_regex="$rest"
+      matched=1
+      break
+    fi
+  done
+  [ $matched -eq 0 ] && { printf '%s' "$cmd"; return; }
+
+  # Walk tokens after the verb, collect every flag-value that the
+  # sink row recognises.
+  local -a payloads=()
+  local i=$((verb_idx + 1)) n=${#_SF_TOKS[@]}
+  while [ $i -lt $n ]; do
+    local raw="${_SF_TOKS[$i]}" tok val="" hit=0
+    tok=$(strip_quotes "$raw")
+
+    if [ -n "$sink_long" ] && [[ "$tok" == "${sink_long}="* ]]; then
+      val="${tok#${sink_long}=}"
+      val=$(strip_quotes "$val")
+      hit=1; i=$((i + 1))
+    elif [ -n "$sink_long" ] && [ "$tok" = "$sink_long" ] && [ $((i + 1)) -lt $n ]; then
+      val=$(strip_quotes "${_SF_TOKS[$((i + 1))]}")
+      hit=1; i=$((i + 2))
+    elif [ -n "$sink_short" ] && [ "$tok" = "$sink_short" ] && [ $((i + 1)) -lt $n ]; then
+      val=$(strip_quotes "${_SF_TOKS[$((i + 1))]}")
+      hit=1; i=$((i + 2))
+    elif [ -n "$sink_short" ] && [[ "$tok" == "${sink_short}"* ]] && [ "$tok" != "$sink_short" ]; then
+      val="${tok#${sink_short}}"
+      val=$(strip_quotes "$val")
+      hit=1; i=$((i + 1))
+    else
+      i=$((i + 1)); continue
+    fi
+
+    [ $hit -eq 0 ] && continue
+    [ -z "$val" ] && continue
+
+    if [ "$sink_kind" = "git-config" ]; then
+      # Value shape is `key=subcmd`. Without an `=` it is not a config
+      # assignment and cannot be an exec sink.
+      case "$val" in *=*) ;; *) continue ;; esac
+      local key="${val%%=*}"
+      local subcmd_val="${val#*=}"
+      if [[ "$key" =~ $sink_key_regex ]]; then
+        payloads+=("$subcmd_val")
+      fi
+    else
+      payloads+=("$val")
+    fi
+  done
+
+  if [ ${#payloads[@]} -eq 0 ]; then
+    printf '%s' "$cmd"
+    return
+  fi
+
+  # Append each payload as a sibling statement. split_and_check splits
+  # on `;` and dispatches each sub-command separately, so the existing
+  # detectors validate the payloads without any per-tool plumbing.
+  printf '%s' "$cmd"
+  local p
+  for p in "${payloads[@]}"; do
+    printf ' ; %s' "$p"
+  done
+}

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -63,7 +63,7 @@
 declare -a SUBCMD_FLAG_SINKS=(
   "tar||--to-command|value|"
   "rsync|-e|--rsh|value|"
-  "git|-c||git-config|^(core\\.(sshCommand|editor|pager|askPass|fsmonitor)|pager\\..+|sequence\\.editor|gpg\\.(program|ssh\\.program|openpgp\\.program|x509\\.program)|credential\\.helper|diff\\.(external|.+\\.(command|textconv))|mergetool\\..+\\.cmd|merge\\..+\\.driver|filter\\..+\\.(clean|smudge|process)|uploadpack\\.packObjectsHook|submodule\\..+\\.update)$"
+  "git|-c||git-config|^(core\\.(sshCommand|editor|pager|askPass|fsmonitor)|pager\\..+|sequence\\.editor|gpg\\.(program|ssh\\.program|openpgp\\.program|x509\\.program)|credential\\.helper|diff\\.(external|.+\\.(command|textconv))|mergetool\\..+\\.cmd|merge\\..+\\.driver|filter\\..+\\.(clean|smudge|process)|uploadpack\\.packObjectsHook|submodule\\..+\\.update|alias\\..+)$"
 )
 
 # --- Find verb token index, skipping wrappers / VAR=val / flags ---
@@ -212,11 +212,17 @@ extract_subcmd_flag_payloads() {
       [[ "$key" =~ $sink_key_regex ]] && _sf_key_match=1
       [ $_sf_nocase_was_on -eq 1 ] || shopt -u nocasematch
       if [ $_sf_key_match -eq 1 ]; then
-        # `submodule.<n>.update` is only an exec sink when the value
-        # starts with `!` — every other value is a reserved word
-        # (rebase / merge / checkout / none). Strip the bang before
-        # dispatching; skip altogether if it is missing.
-        if [[ "$key" =~ ^submodule\..+\.update$ ]]; then
+        # Bang-required keys: only an exec sink when the value
+        # starts with `!`; other values are reserved words or
+        # internal subcommand names (e.g. `submodule.<n>.update`
+        # accepts `rebase`/`merge`/`checkout`/`none`; `alias.<n>`
+        # without bang is a git-internal subcommand alias). Strip
+        # the bang before dispatching; skip altogether if missing.
+        local _sf_bang_match=0
+        shopt -s nocasematch
+        { [[ "$key" =~ ^submodule\..+\.update$ ]] || [[ "$key" =~ ^alias\..+$ ]]; } && _sf_bang_match=1
+        [ $_sf_nocase_was_on -eq 1 ] || shopt -u nocasematch
+        if [ $_sf_bang_match -eq 1 ]; then
           case "$subcmd_val" in
             '!'*) printf '%s\n' "${subcmd_val#!}" ;;
           esac

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -14,6 +14,7 @@
 #
 #   tar -xf … --to-command=<cmd>          [section 29]
 #   rsync -e / --rsh=<cmd>                [section 30]
+#   git -c core.sshCommand=<cmd>          [section 31]
 #
 # The rewrite is intentionally simple: pull each sub-command value out
 # of the original command string and re-emit it as a sibling statement
@@ -53,6 +54,7 @@
 declare -a SUBCMD_FLAG_SINKS=(
   "tar||--to-command|value|"
   "rsync|-e|--rsh|value|"
+  "git|-c||git-config|^core\\.sshCommand$"
 )
 
 # --- Find verb token index, skipping wrappers / VAR=val / flags ---

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -200,7 +200,18 @@ extract_subcmd_flag_payloads() {
       # `key='!cmd ...'` with the quotes intact). Strip them here so
       # the bang-prefix check below sees the real first character.
       subcmd_val=$(strip_quotes "$subcmd_val")
-      if [[ "$key" =~ $sink_key_regex ]]; then
+      # git config keys are case-insensitive (`Core.SshCommand` ==
+      # `core.sshCommand`); enable nocasematch around the regex test
+      # so case-folded variants are not a bypass route. Save / restore
+      # the previous state to avoid leaking the option to callers.
+      # Reported by Copilot review on PR #23 (subcmd_flags.sh:203).
+      local _sf_nocase_was_on=0
+      shopt -q nocasematch && _sf_nocase_was_on=1
+      shopt -s nocasematch
+      local _sf_key_match=0
+      [[ "$key" =~ $sink_key_regex ]] && _sf_key_match=1
+      [ $_sf_nocase_was_on -eq 1 ] || shopt -u nocasematch
+      if [ $_sf_key_match -eq 1 ]; then
         # `submodule.<n>.update` is only an exec sink when the value
         # starts with `!` — every other value is a reserved word
         # (rebase / merge / checkout / none). Strip the bang before

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -19,6 +19,10 @@
 #       core.editor / core.pager / pager.<cmd> / sequence.editor /
 #       gpg.program / gpg.ssh.program / credential.helper /
 #       diff.external / mergetool.<tool>.cmd
+#   git -c <additional-exec-keys>         [section 35]
+#       core.askPass / core.fsmonitor / uploadpack.packObjectsHook /
+#       filter.<n>.clean / filter.<n>.smudge / filter.<n>.process /
+#       diff.<n>.command / diff.<n>.textconv / merge.<n>.driver
 #
 # The mechanism is intentionally simple: extract each sub-command
 # value from a single (post-split) command and emit one payload per
@@ -56,7 +60,7 @@
 declare -a SUBCMD_FLAG_SINKS=(
   "tar||--to-command|value|"
   "rsync|-e|--rsh|value|"
-  "git|-c||git-config|^(core\\.(sshCommand|editor|pager)|pager\\..+|sequence\\.editor|gpg\\.(program|ssh\\.program)|credential\\.helper|diff\\.external|mergetool\\..+\\.cmd)$"
+  "git|-c||git-config|^(core\\.(sshCommand|editor|pager|askPass|fsmonitor)|pager\\..+|sequence\\.editor|gpg\\.(program|ssh\\.program)|credential\\.helper|diff\\.(external|.+\\.(command|textconv))|mergetool\\..+\\.cmd|merge\\..+\\.driver|filter\\..+\\.(clean|smudge|process)|uploadpack\\.packObjectsHook)$"
 )
 
 # --- Find verb token index, skipping wrappers / VAR=val / flags ---

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -20,27 +20,25 @@
 #       gpg.program / gpg.ssh.program / credential.helper /
 #       diff.external / mergetool.<tool>.cmd
 #
-# The rewrite is intentionally simple: pull each sub-command value out
-# of the original command string and re-emit it as a sibling statement
-# joined by `;`. The downstream split_and_check splitter picks the new
-# statement up automatically and dispatches it through the normal
-# check_single_command pipeline — so every existing destructive /
-# write-target walker validates the payload without any per-tool
-# duplication of detection logic.
+# The mechanism is intentionally simple: extract each sub-command
+# value from a single (post-split) command and emit one payload per
+# line on stdout. The caller — check_single_command in guard.sh —
+# recursively dispatches each payload through itself, so every
+# existing destructive / write-target walker validates the payload
+# without any per-tool duplication of detection logic.
 #
-#   tar -xf foo.tar --to-command='rm /etc/x'
-#     → tar -xf foo.tar --to-command='rm /etc/x' ; rm /etc/x
+#   tar -xf foo.tar --to-command='<destructive-payload>'
+#     → check_single_command "<destructive-payload>"
 #
-# The original verb invocation is preserved verbatim. The walkers
-# already ignore the literal `rm /etc/x` bytes inside the quoted
-# `--to-command=` value (they only match command names at token-start
-# positions, not inside a single arg token), so the original side of
-# the rewrite produces no extra detector hits — only the appended
-# sibling statement is validated as a real command.
+# Must run PER SUBCOMMAND (i.e. inside check_single_command, AFTER
+# split_and_check has split the chained command line on `;` / `&&`
+# / `||` / `|` / newline). Routing the extraction earlier — before
+# the splitter — would only catch the FIRST verb of a chained
+# command, leaving any sink in a later subcommand undetected
+# (Copilot review on PR #23, options.sh:92).
 #
-# Pure (no caller-scope dependencies); returns the rewritten command
-# string on stdout. Depends on hooks/lib/tokenize.sh (tokenize_args,
-# strip_quotes).
+# Pure (no caller-scope dependencies). Depends on
+# hooks/lib/tokenize.sh (tokenize_args, strip_quotes).
 
 # --- Sink table ---
 # Format: "<verb>|<short_flag>|<long_flag_no_eq>|<kind>|<key_regex>"
@@ -102,12 +100,13 @@ _sf_strip_path_prefix() {
   esac
 }
 
-# --- Main entry: append sub-command values as sibling statements ---
-# In:  full CMD string
-# Out: CMD string with each recognised flag-value re-emitted after a
-#      `;` separator; unchanged when no sink row matches the verb or
-#      when no recognised flag carries a value.
-expand_subcmd_flags() {
+# --- Main entry: extract sub-command flag values from one subcommand ---
+# In:  single (post-split) command string
+# Out: zero or more payload strings on stdout, one per line. Empty
+#      output when no sink row matches the verb or no recognised flag
+#      carries a value. Caller dispatches each payload through
+#      check_single_command recursively.
+extract_subcmd_flag_payloads() {
   local cmd="$1"
   _SF_TOKS=()
   local t
@@ -118,7 +117,7 @@ expand_subcmd_flags() {
 
   local verb_idx
   verb_idx=$(_sf_find_verb_idx)
-  [ "$verb_idx" -lt 0 ] && { printf '%s' "$cmd"; return; }
+  [ "$verb_idx" -lt 0 ] && return
 
   local verb
   verb=$(strip_quotes "${_SF_TOKS[$verb_idx]}")
@@ -140,11 +139,10 @@ expand_subcmd_flags() {
       break
     fi
   done
-  [ $matched -eq 0 ] && { printf '%s' "$cmd"; return; }
+  [ $matched -eq 0 ] && return
 
-  # Walk tokens after the verb, collect every flag-value that the
-  # sink row recognises.
-  local -a payloads=()
+  # Walk tokens after the verb, emit every flag-value that the sink
+  # row recognises (one payload per line on stdout).
   local i=$((verb_idx + 1)) n=${#_SF_TOKS[@]}
   while [ $i -lt $n ]; do
     local raw="${_SF_TOKS[$i]}" tok val="" hit=0
@@ -169,7 +167,9 @@ expand_subcmd_flags() {
     fi
 
     [ $hit -eq 0 ] && continue
-    [ -z "$val" ] && continue
+    # Skip empty / whitespace-only values; they cannot be exec sinks
+    # (Codex review on PR #23, Q4).
+    [[ -z "${val//[[:space:]]/}" ]] && continue
 
     if [ "$sink_kind" = "git-config" ]; then
       # Value shape is `key=subcmd`. Without an `=` it is not a config
@@ -178,24 +178,10 @@ expand_subcmd_flags() {
       local key="${val%%=*}"
       local subcmd_val="${val#*=}"
       if [[ "$key" =~ $sink_key_regex ]]; then
-        payloads+=("$subcmd_val")
+        printf '%s\n' "$subcmd_val"
       fi
     else
-      payloads+=("$val")
+      printf '%s\n' "$val"
     fi
-  done
-
-  if [ ${#payloads[@]} -eq 0 ]; then
-    printf '%s' "$cmd"
-    return
-  fi
-
-  # Append each payload as a sibling statement. split_and_check splits
-  # on `;` and dispatches each sub-command separately, so the existing
-  # detectors validate the payloads without any per-tool plumbing.
-  printf '%s' "$cmd"
-  local p
-  for p in "${payloads[@]}"; do
-    printf ' ; %s' "$p"
   done
 }

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -23,6 +23,9 @@
 #       core.askPass / core.fsmonitor / uploadpack.packObjectsHook /
 #       filter.<n>.clean / filter.<n>.smudge / filter.<n>.process /
 #       diff.<n>.command / diff.<n>.textconv / merge.<n>.driver
+#   git -c <bang-prefixed-exec-keys>      [section 36]
+#       gpg.openpgp.program / gpg.x509.program /
+#       submodule.<n>.update (with leading `!`)
 #
 # The mechanism is intentionally simple: extract each sub-command
 # value from a single (post-split) command and emit one payload per
@@ -60,7 +63,7 @@
 declare -a SUBCMD_FLAG_SINKS=(
   "tar||--to-command|value|"
   "rsync|-e|--rsh|value|"
-  "git|-c||git-config|^(core\\.(sshCommand|editor|pager|askPass|fsmonitor)|pager\\..+|sequence\\.editor|gpg\\.(program|ssh\\.program)|credential\\.helper|diff\\.(external|.+\\.(command|textconv))|mergetool\\..+\\.cmd|merge\\..+\\.driver|filter\\..+\\.(clean|smudge|process)|uploadpack\\.packObjectsHook)$"
+  "git|-c||git-config|^(core\\.(sshCommand|editor|pager|askPass|fsmonitor)|pager\\..+|sequence\\.editor|gpg\\.(program|ssh\\.program|openpgp\\.program|x509\\.program)|credential\\.helper|diff\\.(external|.+\\.(command|textconv))|mergetool\\..+\\.cmd|merge\\..+\\.driver|filter\\..+\\.(clean|smudge|process)|uploadpack\\.packObjectsHook|submodule\\..+\\.update)$"
 )
 
 # --- Find verb token index, skipping wrappers / VAR=val / flags ---
@@ -192,8 +195,23 @@ extract_subcmd_flag_payloads() {
       case "$val" in *=*) ;; *) continue ;; esac
       local key="${val%%=*}"
       local subcmd_val="${val#*=}"
+      # The token tokenizer keeps surrounding quotes around an
+      # attached value (e.g. `--c-flag-token` looks like
+      # `key='!cmd ...'` with the quotes intact). Strip them here so
+      # the bang-prefix check below sees the real first character.
+      subcmd_val=$(strip_quotes "$subcmd_val")
       if [[ "$key" =~ $sink_key_regex ]]; then
-        printf '%s\n' "$subcmd_val"
+        # `submodule.<n>.update` is only an exec sink when the value
+        # starts with `!` — every other value is a reserved word
+        # (rebase / merge / checkout / none). Strip the bang before
+        # dispatching; skip altogether if it is missing.
+        if [[ "$key" =~ ^submodule\..+\.update$ ]]; then
+          case "$subcmd_val" in
+            '!'*) printf '%s\n' "${subcmd_val#!}" ;;
+          esac
+        else
+          printf '%s\n' "$subcmd_val"
+        fi
       fi
     else
       printf '%s\n' "$val"

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -162,6 +162,17 @@ extract_subcmd_flag_payloads() {
       val="${tok#${sink_short}}"
       val=$(strip_quotes "$val")
       hit=1; i=$((i + 1))
+    elif [ -n "$sink_short" ] \
+        && [ "$tok" != "$sink_short" ] \
+        && [[ "$tok" == -[!-]*"${sink_short#-}" ]] \
+        && [ $((i + 1)) -lt $n ]; then
+      # Clustered short-flag form: `-avze <val>` where the cluster's
+      # last char matches the sink's short-flag letter and consumes
+      # the next token as its value (Copilot review on PR #23,
+      # subcmd_flags.sh:167). Excludes long flags (`--rsh`) via
+      # `-[!-]*` and the bare short flag via the inequality test.
+      val=$(strip_quotes "${_SF_TOKS[$((i + 1))]}")
+      hit=1; i=$((i + 2))
     else
       i=$((i + 1)); continue
     fi

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -15,6 +15,10 @@
 #   tar -xf … --to-command=<cmd>          [section 29]
 #   rsync -e / --rsh=<cmd>                [section 30]
 #   git -c core.sshCommand=<cmd>          [section 31]
+#   git -c <other-exec-key>=<cmd>         [section 32]
+#       core.editor / core.pager / pager.<cmd> / sequence.editor /
+#       gpg.program / gpg.ssh.program / credential.helper /
+#       diff.external / mergetool.<tool>.cmd
 #
 # The rewrite is intentionally simple: pull each sub-command value out
 # of the original command string and re-emit it as a sibling statement
@@ -54,7 +58,7 @@
 declare -a SUBCMD_FLAG_SINKS=(
   "tar||--to-command|value|"
   "rsync|-e|--rsh|value|"
-  "git|-c||git-config|^core\\.sshCommand$"
+  "git|-c||git-config|^(core\\.(sshCommand|editor|pager)|pager\\..+|sequence\\.editor|gpg\\.(program|ssh\\.program)|credential\\.helper|diff\\.external|mergetool\\..+\\.cmd)$"
 )
 
 # --- Find verb token index, skipping wrappers / VAR=val / flags ---

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -13,6 +13,7 @@
 # in CLAUDE.md):
 #
 #   tar -xf … --to-command=<cmd>          [section 29]
+#   rsync -e / --rsh=<cmd>                [section 30]
 #
 # The rewrite is intentionally simple: pull each sub-command value out
 # of the original command string and re-emit it as a sibling statement
@@ -51,6 +52,7 @@
 #   key_regex    - bash extended regex; used only when kind=git-config.
 declare -a SUBCMD_FLAG_SINKS=(
   "tar||--to-command|value|"
+  "rsync|-e|--rsh|value|"
 )
 
 # --- Find verb token index, skipping wrappers / VAR=val / flags ---

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -107,6 +107,94 @@ _sf_strip_path_prefix() {
   esac
 }
 
+# --- Bang-prefix keys list (case-insensitive match) ---
+# Keys whose value is an exec sink ONLY when prefixed with `!`.
+# Centralised so the `-c` and `git config` branches use the same
+# rule. Reads $key from the caller's scope.
+_sf_key_requires_bang() {
+  local k="$1"
+  local was=0
+  shopt -q nocasematch && was=1
+  shopt -s nocasematch
+  local hit=0
+  { [[ "$k" =~ ^submodule\..+\.update$ ]] || [[ "$k" =~ ^alias\..+$ ]]; } && hit=1
+  [ $was -eq 1 ] || shopt -u nocasematch
+  return $((1 - hit))
+}
+
+# --- Helper: emit payload from a (key, value) pair, honouring bang rules ---
+_sf_emit_git_config_payload() {
+  local key="$1" subcmd_val="$2"
+  if _sf_key_requires_bang "$key"; then
+    case "$subcmd_val" in
+      '!'*) printf '%s\n' "${subcmd_val#!}" ;;
+    esac
+  else
+    printf '%s\n' "$subcmd_val"
+  fi
+}
+
+# --- `git config [opts] <key> <value>` form ---
+# Long-form alternative to `git -c <key>=<value>`. Setting an exec-
+# sink config persistently runs the same shell command at the next
+# git operation, so the value still needs validation. Reads tokens
+# from the module-local _SF_TOKS array.
+_sf_try_git_config_form() {
+  local v_idx="$1" key_regex="$2"
+  local n=${#_SF_TOKS[@]}
+
+  # Find the first non-flag, non-VAR=val token after the verb;
+  # that is the subverb (`config` for this form).
+  local subverb_idx=$((v_idx + 1))
+  while [ $subverb_idx -lt $n ]; do
+    local raw="${_SF_TOKS[$subverb_idx]}" t
+    t=$(strip_quotes "$raw")
+    case "$t" in
+      [A-Za-z_]*=*|-*) subverb_idx=$((subverb_idx + 1)); continue ;;
+    esac
+    break
+  done
+  [ $subverb_idx -ge $n ] && return
+  local subverb
+  subverb=$(strip_quotes "${_SF_TOKS[$subverb_idx]}")
+  [ "$subverb" = "config" ] || return
+
+  # Walk past `config`, collect at most two positionals (key, value).
+  # Two-token flags (`--file PATH`, `--blob OBJ`) consume their value;
+  # read-only flags (`--get*`, `--list`, `-l`) bail entirely.
+  local i=$((subverb_idx + 1))
+  local -a positionals=()
+  while [ $i -lt $n ] && [ ${#positionals[@]} -lt 2 ]; do
+    local raw="${_SF_TOKS[$i]}" t
+    t=$(strip_quotes "$raw")
+    case "$t" in
+      --file|--blob) i=$((i + 2)); continue ;;
+      --get|--get-all|--get-regexp|--get-urlmatch|--list|-l|--show-origin|--show-scope|--name-only|-e|--edit)
+        return ;;
+      --file=*|--blob=*|--unset|--unset-all|--add|--replace-all|--type=*|--null|-z|--global|--system|--local|--worktree|--includes|--no-includes|--default=*|--int|--bool|--bool-or-int|--path|--expiry-date|--*|-*)
+        i=$((i + 1)); continue ;;
+    esac
+    positionals+=("$raw")
+    i=$((i + 1))
+  done
+
+  [ ${#positionals[@]} -lt 2 ] && return
+
+  local key val
+  key=$(strip_quotes "${positionals[0]}")
+  val=$(strip_quotes "${positionals[1]}")
+
+  local _was=0
+  shopt -q nocasematch && _was=1
+  shopt -s nocasematch
+  local _match=0
+  [[ "$key" =~ $key_regex ]] && _match=1
+  [ $_was -eq 1 ] || shopt -u nocasematch
+  [ $_match -eq 0 ] && return
+
+  _sf_emit_git_config_payload "$key" "$val"
+}
+
 # --- Main entry: extract sub-command flag values from one subcommand ---
 # In:  single (post-split) command string
 # Out: zero or more payload strings on stdout, one per line. Empty
@@ -212,26 +300,18 @@ extract_subcmd_flag_payloads() {
       [[ "$key" =~ $sink_key_regex ]] && _sf_key_match=1
       [ $_sf_nocase_was_on -eq 1 ] || shopt -u nocasematch
       if [ $_sf_key_match -eq 1 ]; then
-        # Bang-required keys: only an exec sink when the value
-        # starts with `!`; other values are reserved words or
-        # internal subcommand names (e.g. `submodule.<n>.update`
-        # accepts `rebase`/`merge`/`checkout`/`none`; `alias.<n>`
-        # without bang is a git-internal subcommand alias). Strip
-        # the bang before dispatching; skip altogether if missing.
-        local _sf_bang_match=0
-        shopt -s nocasematch
-        { [[ "$key" =~ ^submodule\..+\.update$ ]] || [[ "$key" =~ ^alias\..+$ ]]; } && _sf_bang_match=1
-        [ $_sf_nocase_was_on -eq 1 ] || shopt -u nocasematch
-        if [ $_sf_bang_match -eq 1 ]; then
-          case "$subcmd_val" in
-            '!'*) printf '%s\n' "${subcmd_val#!}" ;;
-          esac
-        else
-          printf '%s\n' "$subcmd_val"
-        fi
+        _sf_emit_git_config_payload "$key" "$subcmd_val"
       fi
     else
       printf '%s\n' "$val"
     fi
   done
+
+  # `git config [opts] <key> <value>` — alternative assignment form
+  # of git's exec-sink config keys (same key regex, different shape
+  # than the `-c` flag). Run after the main walk so the `-c` flow
+  # is unaffected. Reported by Codex review round-3 on PR #23.
+  if [ "$verb" = "git" ] && [ "$sink_kind" = "git-config" ]; then
+    _sf_try_git_config_form "$verb_idx" "$sink_key_regex"
+  fi
 }

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -176,3 +176,76 @@ expect_allowed "git -c alias.lg='log --oneline' status (alias data)" \
   "git -c alias.lg='log --oneline' status"
 
 echo ""
+
+# ============================================================
+# 32. git -c <other-exec-sink-keys> — extend the key regex
+# ------------------------------------------------------------
+# git has more exec-sink config keys than just core.sshCommand
+# (covered in section 31). Each of these substitutes the value as
+# the program git invokes for some subsystem:
+#
+#   core.editor               commit / tag -a / rebase -i
+#   core.pager / pager.<cmd>  output paging
+#   sequence.editor           rebase -i todo edit
+#   gpg.program / gpg.ssh.program  signing
+#   credential.helper         auth
+#   diff.external             custom diff
+#   mergetool.<tool>.cmd      merge tool invocation
+#
+# This section extends the git-config kind's key regex to cover the
+# whole class. Benign data-only keys (user.*, color.*, alias.*,
+# init.*, http.proxy, safe.directory) must remain ALLOWED.
+#
+# Reported by Codex review follow-up after section 31.
+# ============================================================
+echo "--- 32. git -c extended exec-sink key coverage ---"
+
+expect_blocked "git -c core.editor='rm /etc/x' commit" \
+  "git -c core.editor='rm /etc/passwd_test' commit"
+
+expect_blocked "git -c core.pager='rm /etc/x' log" \
+  "git -c core.pager='rm /etc/passwd_test' log"
+
+expect_blocked "git -c pager.log='rm /etc/x' log (per-subcmd pager)" \
+  "git -c pager.log='rm /etc/passwd_test' log"
+
+expect_blocked "git -c sequence.editor='rm /etc/x' rebase" \
+  "git -c sequence.editor='rm /etc/passwd_test' rebase -i HEAD~1"
+
+expect_blocked "git -c gpg.program='rm /etc/x' commit -S" \
+  "git -c gpg.program='rm /etc/passwd_test' commit -S"
+
+expect_blocked "git -c gpg.ssh.program='rm /etc/x' commit -S" \
+  "git -c gpg.ssh.program='rm /etc/passwd_test' commit -S"
+
+expect_blocked "git -c credential.helper='rm /etc/x' fetch" \
+  "git -c credential.helper='rm /etc/passwd_test' fetch"
+
+expect_blocked "git -c diff.external='rm /etc/x' diff" \
+  "git -c diff.external='rm /etc/passwd_test' diff"
+
+expect_blocked "git -c mergetool.foo.cmd='rm /etc/x' mergetool" \
+  "git -c mergetool.foo.cmd='rm /etc/passwd_test' mergetool"
+
+# Positive cases — benign data keys must remain ALLOWED:
+expect_allowed "git -c http.proxy=http://proxy:8080 fetch (URL data)" \
+  "git -c http.proxy=http://proxy:8080 fetch"
+
+expect_allowed "git -c safe.directory=/path status (path data)" \
+  "git -c safe.directory=/some/path status"
+
+expect_allowed "git -c init.defaultBranch=main init" \
+  "git -c init.defaultBranch=main init"
+
+expect_allowed "git -c push.default=current push" \
+  "git -c push.default=current push"
+
+expect_allowed "git -c color.diff=auto diff (color benign)" \
+  "git -c color.diff=auto diff"
+
+# Edge: pager.log='less -R' is a benign pager invocation (in-project
+# binary `less`, no destructive payload). Validator must accept.
+expect_allowed "git -c pager.log='less -R' log (benign pager)" \
+  "git -c pager.log='less -R' log"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -121,3 +121,58 @@ expect_allowed "rsync --version" \
   "rsync --version"
 
 echo ""
+
+# ============================================================
+# 31. git -c core.sshCommand=<cmd> sink
+# ------------------------------------------------------------
+# git's `-c <key>=<value>` flag sets a config value for the duration
+# of one invocation. Several config keys are exec sinks: git uses
+# their value as the command line for an external program (ssh, gpg,
+# editor, credential helper, pager, ...). `core.sshCommand` is the
+# canonical example — its value replaces the ssh invocation when git
+# opens a remote connection, and a destructive value runs locally.
+#
+# Different shape from sections 29 / 30: the flag value is `key=cmd`
+# (a config assignment), not the command directly. Only specific
+# keys are exec sinks; benign keys like `user.name` carry data, not
+# code. The new "git-config" kind in SUBCMD_FLAG_SINKS uses a key
+# regex to discriminate.
+#
+# This section pins the regression for `core.sshCommand` only;
+# section 32 extends the regex to gpg.program / core.editor /
+# credential.helper / pager.*.
+#
+# Reported by adversarial round-2 review (Claude Code session,
+# 2026-05-04).
+# ============================================================
+echo "--- 31. git -c core.sshCommand sink ---"
+
+expect_blocked "git -c core.sshCommand='rm /etc/x' (detached)" \
+  "git -c core.sshCommand='rm /etc/passwd_test' clone foo"
+
+expect_blocked "git -c core.sshCommand=\"rm /etc/x\" (double-quoted)" \
+  "git -c core.sshCommand=\"rm /etc/passwd_test\" fetch"
+
+expect_blocked "git -ccore.sshCommand='rm /etc/x' (attached short form)" \
+  "git -ccore.sshCommand='rm /etc/passwd_test' clone foo"
+
+# Positive cases that must remain ALLOWED after the fix:
+# - git with no -c
+# - git -c with a benign config key carrying ordinary data
+# - git -c with a key NOT in the exec-sink regex (color.ui, alias.*)
+expect_allowed "git status (no -c)" \
+  "git status"
+
+expect_allowed "git -c user.name='Foo Bar' status (benign data)" \
+  "git -c user.name='Foo Bar' status"
+
+expect_allowed "git -c user.email=foo@bar.com status" \
+  "git -c user.email=foo@bar.com status"
+
+expect_allowed "git -c color.ui=true status (benign config)" \
+  "git -c color.ui=true status"
+
+expect_allowed "git -c alias.lg='log --oneline' status (alias data)" \
+  "git -c alias.lg='log --oneline' status"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -74,3 +74,50 @@ expect_allowed "tar -xf --to-command='rm PROJECT/file' (in-project rm payload)" 
   "tar -xf $PROJECT/archive.tar --to-command='rm $PROJECT/tests/scratch.txt'"
 
 echo ""
+
+# ============================================================
+# 30. rsync -e / --rsh=<cmd> sink
+# ------------------------------------------------------------
+# rsync's -e (short) / --rsh (long) flag substitutes a custom remote
+# shell. rsync passes the substituted string to a `sh -c` invocation
+# at runtime, so a value like `rm /etc/x` is a live exec sink the
+# moment rsync would actually start a connection. Same shape as
+# tar --to-command (section 29).
+#
+# Both attached and detached forms must be covered: `rsync -e VAL`,
+# `rsync -eVAL`, `rsync --rsh=VAL`, `rsync --rsh VAL`.
+#
+# Reported by adversarial round-2 review (Claude Code session,
+# 2026-05-04).
+# ============================================================
+echo "--- 30. rsync -e / --rsh sink ---"
+
+expect_blocked "rsync -e 'rm /etc/x' (short detached)" \
+  "rsync -e 'rm /etc/passwd_test' $PROJECT/CHANGELOG.md host:/dst"
+
+expect_blocked "rsync --rsh='rm /etc/x' (long attached)" \
+  "rsync --rsh='rm /etc/passwd_test' $PROJECT/CHANGELOG.md host:/dst"
+
+expect_blocked "rsync --rsh 'rm /etc/x' (long detached)" \
+  "rsync --rsh 'rm /etc/passwd_test' $PROJECT/CHANGELOG.md host:/dst"
+
+expect_blocked "rsync -e \"sed -i s/a/b/ /etc/x\" (short detached, sed payload)" \
+  "rsync -e \"sed -i 's/a/b/' /etc/passwd_test\" $PROJECT/CHANGELOG.md host:/dst"
+
+# Positive cases that must remain ALLOWED after the fix:
+# - rsync without -e / --rsh
+# - rsync with benign -e value (ssh / ssh -p 22 — no destructive path)
+# - rsync --version, --help
+expect_allowed "rsync -a src dst (no -e, in project)" \
+  "rsync -a $PROJECT/CHANGELOG.md $PROJECT/tests/scratch.txt"
+
+expect_allowed "rsync -e ssh src host:dst (benign ssh value)" \
+  "rsync -e ssh $PROJECT/CHANGELOG.md host:/dst"
+
+expect_allowed "rsync --rsh='ssh -p 2222' src host:dst (ssh with port)" \
+  "rsync --rsh='ssh -p 2222' $PROJECT/CHANGELOG.md host:/dst"
+
+expect_allowed "rsync --version" \
+  "rsync --version"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -302,3 +302,45 @@ expect_allowed "git status && rsync -e ssh src host:dst (benign chain)" \
   "git status && rsync -e ssh $PROJECT/CHANGELOG.md host:/dst"
 
 echo ""
+
+# ============================================================
+# 34. rsync clustered short flags — `-avze <cmd>`
+# ------------------------------------------------------------
+# rsync (and getopt-style CLIs in general) accepts clustered short
+# flags: `-avze` is shorthand for `-a -v -z -e`. Because `-e`
+# consumes the next token as its value, a clustered form ending in
+# `e` makes the following token the exec-sink value. The previous
+# parser only recognised `-e VAL` (own token) and `-eVAL` (attached
+# form), so `rsync -avze 'rm /etc/x' src host:dst` slipped through.
+#
+# Fix: when the token is a short-flag cluster (starts with `-`,
+# does not start with `--`, longer than the bare short flag, and
+# its last character matches the sink's short-flag letter), treat
+# it like a detached short flag — consume the next token as the
+# value.
+#
+# Reported by Copilot review on PR #23 (subcmd_flags.sh:167).
+# ============================================================
+echo "--- 34. rsync clustered short flags ---"
+
+expect_blocked "rsync -avze 'rm /etc/x' src host:dst (full cluster)" \
+  "rsync -avze 'rm /etc/passwd_test' $PROJECT/CHANGELOG.md host:/dst"
+
+expect_blocked "rsync -ae 'rm /etc/x' src host:dst (minimal cluster)" \
+  "rsync -ae 'rm /etc/passwd_test' $PROJECT/CHANGELOG.md host:/dst"
+
+expect_blocked "rsync -ze 'rm /etc/x' src host:dst (compress + e)" \
+  "rsync -ze 'rm /etc/passwd_test' $PROJECT/CHANGELOG.md host:/dst"
+
+# Positive cases: clustered forms with a benign value, or clusters
+# whose last char is NOT `e` (no exec sink consumed).
+expect_allowed "rsync -avze ssh src host:dst (benign cluster)" \
+  "rsync -avze ssh $PROJECT/CHANGELOG.md host:/dst"
+
+expect_allowed "rsync -avz src dst (no -e at end)" \
+  "rsync -avz $PROJECT/CHANGELOG.md $PROJECT/tests/scratch.txt"
+
+expect_allowed "rsync -avzh src dst (cluster ends in -h, not exec sink)" \
+  "rsync -avzh $PROJECT/CHANGELOG.md $PROJECT/tests/scratch.txt"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -249,3 +249,56 @@ expect_allowed "git -c pager.log='less -R' log (benign pager)" \
   "git -c pager.log='less -R' log"
 
 echo ""
+
+# ============================================================
+# 33. Chained sub-commands must each be expanded (not just the first)
+# ------------------------------------------------------------
+# expand_subcmd_flags was applied to the FULL command string before
+# split_and_check splits on `;` / `&&` / `||` / `|` / newline, but
+# the function only inspected the FIRST verb. A chained command
+# whose later subcommand carries the exec-sink flag was therefore
+# never expanded — every walker downstream saw only the original
+# (un-routed) value, and the destructive payload slipped through.
+#
+# Example:
+#   echo ok ; tar -xf foo --to-command='rm /etc/x'
+# Pre-fix: expand_subcmd_flags inspects `echo`, finds no sink, the
+# full string is split into [echo ok, tar ... --to-command=...]
+# and check_single_command runs on each subcommand. The tar
+# subcommand still has the unrouted --to-command= value — same
+# state as before any patch.
+#
+# Fix: route the expansion per-subcommand, after splitting. The
+# refactor lifts payload extraction into check_single_command and
+# recursively dispatches each payload through the same function.
+# Heredoc-related edge cases collapse with the same change because
+# the new path never mutates the chained command string.
+#
+# Reported by Copilot review on PR #23 (options.sh:92).
+# ============================================================
+echo "--- 33. chained sub-commands per-subcmd expansion ---"
+
+expect_blocked "echo ok ; tar -xf … --to-command='rm /etc/x' (chained ;)" \
+  "echo ok ; tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+expect_blocked "git status && tar --to-command='rm /etc/x' (chained &&)" \
+  "git status && tar --to-command='rm /etc/passwd_test' -xf $PROJECT/archive.tar"
+
+expect_blocked "false || rsync --rsh='rm /etc/x' (chained ||)" \
+  "false || rsync --rsh='rm /etc/passwd_test' $PROJECT/CHANGELOG.md host:/dst"
+
+expect_blocked "true | git -c core.sshCommand='rm /etc/x' clone (pipe)" \
+  "true | git -c core.sshCommand='rm /etc/passwd_test' clone foo"
+
+expect_blocked "tar … --to-command='rm /etc/x' AS LATER subcmd in newline-chain" \
+  "echo first
+tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+# Positive: chained legitimate commands must remain ALLOWED.
+expect_allowed "echo ok ; tar -xf in-project (no destructive payload)" \
+  "echo ok ; tar -xf $PROJECT/archive.tar -C $PROJECT/extracted"
+
+expect_allowed "git status && rsync -e ssh src host:dst (benign chain)" \
+  "git status && rsync -e ssh $PROJECT/CHANGELOG.md host:/dst"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -567,3 +567,53 @@ expect_allowed "git config --global user.email foo@bar.com" \
   "git config --global user.email foo@bar.com"
 
 echo ""
+
+# ============================================================
+# 40. sudo / env / timeout opt-flags before the real verb
+# ------------------------------------------------------------
+# `_sf_find_verb_idx` skipped the wrapper command (`sudo`, `env`,
+# `nohup`, `timeout`, ...) but not its OPTION-WITH-VALUE flags.
+# For common forms like `sudo -u root tar --to-command='<payload>'`
+# the verb-finder treated `root` as the verb (not `tar`), so the
+# sink table never matched and the destructive payload slipped
+# past extract_subcmd_flag_payloads entirely.
+#
+# Fix: per-wrapper list of options-that-consume-the-next-token,
+# walked alongside the wrapper-skip pass. `sudo -u USER`,
+# `env -u VAR`, `timeout -k DUR`, `timeout -s SIG`, etc. now
+# advance the verb-finder past both the flag and its value.
+# Bonus: timeout duration suffix matching extended with `inf`/
+# `infinity`.
+#
+# Reported by Copilot review on PR #23 (guard.sh:897 — verb
+# mis-identification under sudo / env wrappers; subcmd_flags.sh:84
+# — timeout duration suffixes).
+# ============================================================
+echo "--- 40. wrapper opt-flags before verb ---"
+
+expect_blocked "sudo -u root tar --to-command='rm /etc/x'" \
+  "sudo -u root tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+expect_blocked "sudo --user=root tar (long attached, already ok) + payload" \
+  "sudo --user=root tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+expect_blocked "env -u FOO tar --to-command='rm /etc/x'" \
+  "env -u FOO tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+expect_blocked "timeout -k 5 10 tar --to-command='rm /etc/x'" \
+  "timeout -k 5 10 tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+expect_blocked "timeout -s 9 1.5s tar --to-command='rm /etc/x' (suffix duration)" \
+  "timeout -s 9 1.5s tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+expect_blocked "nice -n 10 tar --to-command='rm /etc/x'" \
+  "nice -n 10 tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+# Positive: wrapper without exec-sink-bearing verb stays ALLOWED.
+expect_allowed "sudo -u root ls (benign command, no sink)" \
+  "sudo -u root ls"
+
+expect_allowed "env -u FOO PROJECT-relative read (no sink)" \
+  "env -u FOO cat $PROJECT/CHANGELOG.md"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -483,3 +483,37 @@ expect_allowed "git -c USER.Name='Foo Bar' status (case-insensitive non-sink)" \
   "git -c USER.Name='Foo Bar' status"
 
 echo ""
+
+# ============================================================
+# 38. git -c alias.<name>='!cmd' is an exec sink
+# ------------------------------------------------------------
+# git aliases support shell commands when the value starts with
+# `!`. `git -c alias.pwn='!rm /etc/x' pwn` runs the destructive
+# command as a shell command. Section 31 / 32 explicitly excluded
+# `alias.*` from the exec-sink regex (treating it as data only),
+# missing the bang-prefix exec form.
+#
+# Same shape as `submodule.<n>.update` (section 36) — only the
+# bang-prefixed variant is an exec sink. Generalises the previous
+# special-case to a list of bang-required keys: alias.<n>,
+# submodule.<n>.update, credential.helper.
+#
+# Reported by Codex review round-3 on PR #23 (P1).
+# ============================================================
+echo "--- 38. git -c alias.<n>='!cmd' exec sink ---"
+
+expect_blocked "git -c alias.pwn='!rm /etc/x' pwn" \
+  "git -c alias.pwn='!rm /etc/passwd_test' pwn"
+
+expect_blocked "git -c alias.foo='!sed -i s/a/b/ /etc/x' foo" \
+  "git -c alias.foo=\"!sed -i 's/a/b/' /etc/passwd_test\" foo"
+
+# True-negatives: non-bang aliases are git-internal subcommands,
+# not shell commands.
+expect_allowed "git -c alias.lg='log --oneline' lg (no bang)" \
+  "git -c alias.lg='log --oneline' lg"
+
+expect_allowed "git -c alias.co=checkout co (single subcommand)" \
+  "git -c alias.co=checkout co"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -451,3 +451,35 @@ expect_allowed "git -c submodule.foo.update=none submodule update" \
   "git -c submodule.foo.update=none submodule update"
 
 echo ""
+
+# ============================================================
+# 37. git-config keys are case-insensitive
+# ------------------------------------------------------------
+# git treats configuration keys as case-insensitive (`Core.SshCommand`
+# == `core.sshCommand`), but the exec-sink regex match was case-
+# sensitive (`[[ "$key" =~ $regex ]]` without nocasematch). A bypass
+# like `git -c Core.SshCommand='rm /etc/x' clone foo` therefore
+# slipped past the regex.
+#
+# Fix: enable nocasematch around the regex test (save/restore the
+# previous shopt state so callers are unaffected).
+#
+# Reported by Copilot review on PR #23 (subcmd_flags.sh:203).
+# ============================================================
+echo "--- 37. git-config case-insensitive keys ---"
+
+expect_blocked "git -c Core.SshCommand='rm /etc/x' (CamelCase key)" \
+  "git -c Core.SshCommand='rm /etc/passwd_test' clone foo"
+
+expect_blocked "git -c CORE.SSHCOMMAND='rm /etc/x' (uppercase key)" \
+  "git -c CORE.SSHCOMMAND='rm /etc/passwd_test' clone foo"
+
+expect_blocked "git -c GPG.Program='rm /etc/x' (mixed case)" \
+  "git -c GPG.Program='rm /etc/passwd_test' commit -S"
+
+# True-negative: still differentiate exec keys from data keys
+# (case-insensitively).
+expect_allowed "git -c USER.Name='Foo Bar' status (case-insensitive non-sink)" \
+  "git -c USER.Name='Foo Bar' status"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -517,3 +517,53 @@ expect_allowed "git -c alias.co=checkout co (single subcommand)" \
   "git -c alias.co=checkout co"
 
 echo ""
+
+# ============================================================
+# 39. `git config <key> <value>` form
+# ------------------------------------------------------------
+# `git config` is the long-form alternative to `git -c`. Setting an
+# exec-sink config persistently runs the same shell command at the
+# next git operation; a destructive value is therefore still a
+# live exec sink even when set via `git config` rather than `-c`.
+# Sections 31-38 only recognised the `-c` flag-attached form.
+#
+# Forms to recognise:
+#   git config <key> <value>
+#   git config --global <key> <value>
+#   git config --system <key> <value>
+#   git config --local <key> <value>
+#   git config --file PATH <key> <value>
+#
+# Read-only forms (--get, --list, --get-all, --get-regexp) carry
+# no value to dispatch and must remain ALLOWED.
+#
+# Reported by Codex review round-3 on PR #23 (P2).
+# ============================================================
+echo "--- 39. git config <key> <value> exec-sink form ---"
+
+expect_blocked "git config core.sshCommand 'rm /etc/x'" \
+  "git config core.sshCommand 'rm /etc/passwd_test'"
+
+expect_blocked "git config --global core.sshCommand 'rm /etc/x'" \
+  "git config --global core.sshCommand 'rm /etc/passwd_test'"
+
+expect_blocked "git config --system gpg.program 'rm /etc/x'" \
+  "git config --system gpg.program 'rm /etc/passwd_test'"
+
+expect_blocked "git config --local credential.helper 'rm /etc/x'" \
+  "git config --local credential.helper 'rm /etc/passwd_test'"
+
+# True-negatives:
+expect_allowed "git config user.name 'Foo Bar' (data-only key)" \
+  "git config user.name 'Foo Bar'"
+
+expect_allowed "git config --get core.sshCommand (read-only get)" \
+  "git config --get core.sshCommand"
+
+expect_allowed "git config --list (list subcommand)" \
+  "git config --list"
+
+expect_allowed "git config --global user.email foo@bar.com" \
+  "git config --global user.email foo@bar.com"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -408,3 +408,46 @@ expect_allowed "git -c protocol.allow=user fetch" \
   "git -c protocol.allow=user fetch"
 
 echo ""
+
+# ============================================================
+# 36. More git-config exec-sink keys (gpg.<format>.program, submodule.<n>.update)
+# ------------------------------------------------------------
+# Codex round-2 review on PR #23 (Q8) flagged three more keys:
+#
+#   gpg.openpgp.program        OpenPGP signing program
+#   gpg.x509.program           X.509 / S/MIME signing program
+#   submodule.<name>.update    only an exec sink when value starts
+#                              with `!` (everything else is a
+#                              reserved word: rebase / merge /
+#                              checkout / none).
+#
+# `submodule.<n>.update` requires special handling: the new
+# git-config-bang kind strips the leading `!` before dispatching
+# the payload (and skips values that don't begin with `!`, since
+# those are reserved words, not commands).
+# ============================================================
+echo "--- 36. more git-config exec-sink keys ---"
+
+expect_blocked "git -c gpg.openpgp.program='rm /etc/x' commit -S" \
+  "git -c gpg.openpgp.program='rm /etc/passwd_test' commit -S"
+
+expect_blocked "git -c gpg.x509.program='rm /etc/x' commit -S" \
+  "git -c gpg.x509.program='rm /etc/passwd_test' commit -S"
+
+expect_blocked "git -c submodule.foo.update='!rm /etc/x' submodule update" \
+  "git -c submodule.foo.update='!rm /etc/passwd_test' submodule update"
+
+# Positive cases that must remain ALLOWED:
+expect_allowed "git -c submodule.foo.update=rebase submodule update" \
+  "git -c submodule.foo.update=rebase submodule update"
+
+expect_allowed "git -c submodule.foo.update=merge submodule update" \
+  "git -c submodule.foo.update=merge submodule update"
+
+expect_allowed "git -c submodule.foo.update=checkout submodule update" \
+  "git -c submodule.foo.update=checkout submodule update"
+
+expect_allowed "git -c submodule.foo.update=none submodule update" \
+  "git -c submodule.foo.update=none submodule update"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Bypass reproducers (sections 29+) — argument-as-command sinks.
+#
+# A category of tools that take a SHELL COMMAND as the value of a
+# specific flag and execute it locally at runtime: tar --to-command=,
+# rsync -e= / --rsh=, git -c core.sshCommand= / gpg.program= /
+# core.editor= / credential.helper= / pager.*. The exec happens on
+# the LOCAL filesystem this guard protects, so the value must be
+# walked by the destructive / write-target detectors — but the
+# walkers only see flag names, not flag values.
+#
+# Same shape as the find -exec sink (already covered) and the
+# remote-dispatch verbs from issue #21 (ssh / docker exec / kubectl
+# exec): a side channel that bypasses bare-name regex detection.
+#
+# Sourced by test_guard.sh — requires helpers.sh loaded first.
+
+echo "========================================"
+echo "  Bypass reproducers (flags, sections 29+)"
+echo "  PROJECT_DIR=$PROJECT"
+echo "========================================"
+echo ""
+
+# ============================================================
+# 29. tar --to-command=<cmd> sink
+# ------------------------------------------------------------
+# GNU tar's --to-command flag executes the given shell command for
+# every member of the archive at extract time. A value like
+# `rm /etc/x` is therefore a live exec sink, not opaque data — and
+# the value can sit on either side of the verb / archive operands.
+#
+# Pre-fix: the guard tokenizes the cmd, recognises `tar` and walks
+# its path operands (-C, -f, --file, ...), but never inspects the
+# `--to-command=` value or its space-separated form. Both attached
+# (`--to-command='rm /etc/x'`) and detached (`--to-command 'rm
+# /etc/x'`) shapes pass.
+#
+# Reported by adversarial round-2 review (Claude Code session,
+# 2026-05-04).
+# ============================================================
+echo "--- 29. tar --to-command sink ---"
+
+expect_blocked "tar -xf attached --to-command='rm /etc/x'" \
+  "tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+expect_blocked "tar --extract --file= attached --to-command (long form)" \
+  "tar --extract --file=$PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+expect_blocked "tar -xf detached --to-command 'rm /etc/x' (space form)" \
+  "tar -xf $PROJECT/archive.tar --to-command 'rm /etc/passwd_test'"
+
+expect_blocked "tar -xf attached --to-command with sed -i to /etc" \
+  "tar -xf $PROJECT/archive.tar --to-command=\"sed -i 's/a/b/' /etc/passwd_test\""
+
+expect_blocked "tar -xf with --to-command paired with destructive truncate" \
+  "tar -xf $PROJECT/archive.tar --to-command='truncate -s 0 /etc/passwd_test'"
+
+# Positive cases that must remain ALLOWED after the fix:
+# - tar with no --to-command (current path-walker behaviour preserved)
+# - tar --to-command pointing at a benign read-only command
+# - tar create (-c) with --to-command targeting in-project (literal,
+#   command never actually runs because -c, but the validator must
+#   not over-block on the literal)
+expect_allowed "tar -xf without --to-command (in-project archive)" \
+  "tar -xf $PROJECT/archive.tar -C $PROJECT/extracted"
+
+expect_allowed "tar -xf --to-command='cat' (read-only payload)" \
+  "tar -xf $PROJECT/archive.tar --to-command='cat'"
+
+expect_allowed "tar -xf --to-command='echo done' (literal echo)" \
+  "tar -xf $PROJECT/archive.tar --to-command='echo done'"
+
+expect_allowed "tar -xf --to-command='rm PROJECT/file' (in-project rm payload)" \
+  "tar -xf $PROJECT/archive.tar --to-command='rm $PROJECT/tests/scratch.txt'"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -344,3 +344,67 @@ expect_allowed "rsync -avzh src dst (cluster ends in -h, not exec sink)" \
   "rsync -avzh $PROJECT/CHANGELOG.md $PROJECT/tests/scratch.txt"
 
 echo ""
+
+# ============================================================
+# 35. Additional git-config exec-sink keys
+# ------------------------------------------------------------
+# Section 32 covered the most common exec-sink config keys but
+# missed several that also substitute the value as a program git
+# invokes:
+#
+#   core.askPass               password / passphrase prompt helper
+#   core.fsmonitor             file-system monitor command
+#   uploadpack.packObjectsHook hook run when packing for transfer
+#   filter.<name>.clean        content filter (working tree -> index)
+#   filter.<name>.smudge       content filter (index -> working tree)
+#   filter.<name>.process      long-running filter process
+#   diff.<name>.command        custom diff driver
+#   diff.<name>.textconv       text-conversion command for diff
+#   merge.<name>.driver        custom merge driver
+#
+# Reported by Codex review on PR #23 (Q6).
+# ============================================================
+echo "--- 35. additional git-config exec-sink keys ---"
+
+expect_blocked "git -c core.askPass='rm /etc/x' fetch" \
+  "git -c core.askPass='rm /etc/passwd_test' fetch"
+
+expect_blocked "git -c core.fsmonitor='rm /etc/x' status" \
+  "git -c core.fsmonitor='rm /etc/passwd_test' status"
+
+expect_blocked "git -c uploadpack.packObjectsHook='rm /etc/x' fetch" \
+  "git -c uploadpack.packObjectsHook='rm /etc/passwd_test' fetch"
+
+expect_blocked "git -c filter.lfs.clean='rm /etc/x' add" \
+  "git -c filter.lfs.clean='rm /etc/passwd_test' add file.txt"
+
+expect_blocked "git -c filter.lfs.smudge='rm /etc/x' checkout" \
+  "git -c filter.lfs.smudge='rm /etc/passwd_test' checkout file.txt"
+
+expect_blocked "git -c filter.lfs.process='rm /etc/x' add" \
+  "git -c filter.lfs.process='rm /etc/passwd_test' add file.txt"
+
+expect_blocked "git -c diff.foo.command='rm /etc/x' diff" \
+  "git -c diff.foo.command='rm /etc/passwd_test' diff"
+
+expect_blocked "git -c diff.foo.textconv='rm /etc/x' diff" \
+  "git -c diff.foo.textconv='rm /etc/passwd_test' diff"
+
+expect_blocked "git -c merge.foo.driver='rm /etc/x' merge" \
+  "git -c merge.foo.driver='rm /etc/passwd_test' merge"
+
+# Positive cases — these config keys are NOT exec sinks and must
+# remain ALLOWED:
+expect_allowed "git -c filter.lfs.required=true add (boolean filter config)" \
+  "git -c filter.lfs.required=true add file.txt"
+
+expect_allowed "git -c merge.foo.name='My driver' merge (friendly name string)" \
+  "git -c merge.foo.name='My driver' merge"
+
+expect_allowed "git -c diff.foo.cachetextconv=true diff (boolean)" \
+  "git -c diff.foo.cachetextconv=true diff"
+
+expect_allowed "git -c protocol.allow=user fetch" \
+  "git -c protocol.allow=user fetch"
+
+echo ""

--- a/tests/test_guard.sh
+++ b/tests/test_guard.sh
@@ -11,6 +11,7 @@ source "$SCRIPT_DIR/test_file_guard.sh"
 source "$SCRIPT_DIR/test_true_negatives.sh"
 source "$SCRIPT_DIR/test_bypass_reproducers_core.sh"
 source "$SCRIPT_DIR/test_bypass_reproducers_recent.sh"
+source "$SCRIPT_DIR/test_bypass_reproducers_flags.sh"
 source "$SCRIPT_DIR/test_allowlist.sh"
 source "$SCRIPT_DIR/test_session_hint.sh"
 


### PR DESCRIPTION
## Summary

Closes a class of side-channel bypasses where a destructive shell command was hidden inside a flag value of a popular tool. The path / destructive walkers only inspected flag NAMES, not VALUES — same bug class as `find -exec` (already covered) and the remote-dispatch verbs from issue #21 (ssh / docker exec / kubectl exec).

Four bypasses, one commit each (per CLAUDE.md §Security-bypass TDD flow):

- `afe122b` — section 29 — `tar --to-command=<cmd>` (executes per archive member at extract time)
- `3f7d30a` — section 30 — `rsync -e` / `--rsh=<cmd>` (substitutes custom remote shell)
- `31620a6` — section 31 — `git -c core.sshCommand=<cmd>` (substitutes ssh transport)
- `a220d40` — section 32 — extends git-config key regex to the rest of the exec-sink keys (core.editor / core.pager / pager.* / sequence.editor / gpg.program / gpg.ssh.program / credential.helper / diff.external / mergetool.*.cmd)

## Mechanism (KISS + DRY)

New module `hooks/lib/subcmd_flags.sh` mirrors the shape of `remote_dispatch.sh`: pure string-in / string-out, walks `tokenize_args`, drives a single sink table:

```
declare -a SUBCMD_FLAG_SINKS=(
  "tar||--to-command|value|"
  "rsync|-e|--rsh|value|"
  "git|-c||git-config|<exec-sink-key-regex>"
)
```

Each recognised flag value is appended after a `;` separator on the original command string. The existing `split_and_check` splitter picks the new statement up automatically and dispatches it through the normal `check_single_command` pipeline — every existing detector validates the payload without any per-tool duplication of detection logic.

Two kinds:
- `value` — the flag value IS the shell command (tar, rsync)
- `git-config` — the value is `key=cmd`; only keys matching an exec-sink regex are routed (so `user.name='Foo Bar'` etc. stay benign)

Wired into `split_and_check` as a single line at the top of the function.

## Test plan

- [x] 913/913 tests PASS (28 new tests in sections 29-32)
- [x] Each reproducer FAILED before its commit (TDD discipline; reproducers FAIL first)
- [x] True-negatives prevent benign-use regression:
  - `git -c user.name='Foo Bar'`, `user.email`, `color.ui`, `alias.*`, `init.*`, `http.proxy`, `safe.directory`, `push.*`
  - `rsync -e ssh`, `--rsh='ssh -p 2222'`
  - `tar -xf` without --to-command
  - `pager.log='less -R'` (benign in-project pager)
- [ ] Manual smoke test on a real repo
- [ ] Codex / Copilot review on the PR

## Background

Found by adversarial round-2 review: 12 parser-level bypass attempts against `guard.sh`, 4 of them ALLOWED (the four sinks above). Confirmed live by Codex via subagent. Patch design proposed by Codex, implemented + extended in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
