### PR TITLE
Fix wrapper opt-flags in command_name.sh / remote_dispatch.sh (PR #23 follow-up)

### DIFF
--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -229,11 +229,20 @@ check_single_command() {
   # (guard.sh:897).
   local _CMD_PRE_STRIP="$CMD"
 
-  # --- Strip sudo prefix ---
-  if [[ "$CMD" =~ ^sudo[[:space:]]+ ]]; then
-    CMD="${CMD#sudo }"
-    CMD="$(echo "$CMD" | sed 's/^[[:space:]]*//')"
-  fi
+  # --- Strip sudo prefix and its option-with-value pairs ---
+  # Bare `${CMD#sudo }` left orphaned options like `-u root` in front
+  # of the verb, which then mis-led the wrapper-walk in
+  # strip_command_name_prefix / strip_command_name_quotes /
+  # command_name_is — `root` got treated as the verb and the install
+  # / /bin/<name> / "<name>" normalisations all fell through. The
+  # helper below walks sudo's options-with-value (-u USER, --user=USER,
+  # -g GROUP, …) and value-less flags so `sudo -u root install …`
+  # collapses cleanly to `install …` before any downstream walker
+  # runs. env / nice / ionice / timeout / chrt are NOT literal-stripped
+  # — _cn_find_verb_idx (and its _sf_/_rd_ siblings) handle their
+  # opt-with-value pairs in place. Reported by Codex round-4 on PR #23.
+  CMD=$(strip_sudo_wrapper_with_opts "$CMD")
+  CMD="$(echo "$CMD" | sed 's/^[[:space:]]*//')"
 
   # --- Snapshot raw CMD before alias-escape / paren normalization ---
   # Alias normalization below strips `\` that precedes `[a-zA-Z_]`. That

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -244,24 +244,25 @@ check_single_command() {
   CMD=$(strip_sudo_wrapper_with_opts "$CMD")
   CMD="$(echo "$CMD" | sed 's/^[[:space:]]*//')"
 
-  # --- Empty CMD after sudo-strip: handle shell-opening forms ---
+  # --- Block shell-opening sudo invocations ---
   # `sudo -i` / `sudo -s` / `sudo --login` / `sudo --shell` open a
   # privileged interactive shell whose subsequent commands cannot be
   # inspected by this guard — strictly more dangerous than a bare
   # `bash` invocation, which the existing shell-execute walker
-  # already blocks. After the strip consumes every sudo flag and
-  # reaches the end of the token list, CMD is empty; without this
-  # check the downstream walkers ran on "" (and crashed on
-  # `tokens[@]: unbound variable` under `set -u`) before exiting
-  # ALLOWED. Bare `sudo` / `sudo -l` / `sudo -V` / `sudo -v` are
-  # harmless and stay ALLOWED. Reported by Codex review round-2 on
-  # PR #24 (P2).
+  # already blocks. _cn_is_sudo_shell_opener also detects clustered
+  # forms (`sudo -ni` / `-in` / `-nis`), quoted forms (`sudo "-i"`),
+  # and outer-wrapper-prefixed forms (`env -u FOO sudo -i`), all of
+  # which Codex round-3 found slipped past the earlier regex. Runs
+  # on _CMD_PRE_STRIP so the original wrapper + sudo + flag layout
+  # is still visible. If empty CMD remains after sudo-strip but the
+  # original was bare `sudo` / `sudo -l` / `sudo -V` / `sudo -v`,
+  # this returns 1 and we fall through to the harmless-empty
+  # ALLOW. Reported by Codex review rounds 2–3 on PR #24 (P2).
+  if _cn_is_sudo_shell_opener "$_CMD_PRE_STRIP"; then
+    echo "BLOCKED: 'sudo -i' / 'sudo -s' / 'sudo --login' / 'sudo --shell' (also clustered like -ni / -nis, quoted, or wrapper-prefixed) opens a privileged interactive shell whose subsequent commands cannot be inspected. Ask user for explicit permission." >&2
+    exit 2
+  fi
   if [ -z "$CMD" ]; then
-    if [[ "$_CMD_PRE_STRIP" =~ (^|[[:space:]])-(i|s)([[:space:]]|$) ]] || \
-       [[ "$_CMD_PRE_STRIP" =~ (^|[[:space:]])--(login|shell)([[:space:]]|$) ]]; then
-      echo "BLOCKED: 'sudo -i' / 'sudo -s' / 'sudo --login' / 'sudo --shell' opens a privileged interactive shell whose subsequent commands cannot be inspected. Ask user for explicit permission." >&2
-      exit 2
-    fi
     return 0
   fi
 

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -244,6 +244,27 @@ check_single_command() {
   CMD=$(strip_sudo_wrapper_with_opts "$CMD")
   CMD="$(echo "$CMD" | sed 's/^[[:space:]]*//')"
 
+  # --- Empty CMD after sudo-strip: handle shell-opening forms ---
+  # `sudo -i` / `sudo -s` / `sudo --login` / `sudo --shell` open a
+  # privileged interactive shell whose subsequent commands cannot be
+  # inspected by this guard — strictly more dangerous than a bare
+  # `bash` invocation, which the existing shell-execute walker
+  # already blocks. After the strip consumes every sudo flag and
+  # reaches the end of the token list, CMD is empty; without this
+  # check the downstream walkers ran on "" (and crashed on
+  # `tokens[@]: unbound variable` under `set -u`) before exiting
+  # ALLOWED. Bare `sudo` / `sudo -l` / `sudo -V` / `sudo -v` are
+  # harmless and stay ALLOWED. Reported by Codex review round-2 on
+  # PR #24 (P2).
+  if [ -z "$CMD" ]; then
+    if [[ "$_CMD_PRE_STRIP" =~ (^|[[:space:]])-(i|s)([[:space:]]|$) ]] || \
+       [[ "$_CMD_PRE_STRIP" =~ (^|[[:space:]])--(login|shell)([[:space:]]|$) ]]; then
+      echo "BLOCKED: 'sudo -i' / 'sudo -s' / 'sudo --login' / 'sudo --shell' opens a privileged interactive shell whose subsequent commands cannot be inspected. Ask user for explicit permission." >&2
+      exit 2
+    fi
+    return 0
+  fi
+
   # --- Snapshot raw CMD before alias-escape / paren normalization ---
   # Alias normalization below strips `\` that precedes `[a-zA-Z_]`. That
   # breaks detection of a backslash-escaped heredoc delimiter `<<\EOF`

--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -23,6 +23,8 @@ _GUARD_DIR="$(cd "$(dirname "$_guard_source")" && pwd)"
 unset _guard_source _guard_target
 # shellcheck source=lib/tokenize.sh
 source "$_GUARD_DIR/lib/tokenize.sh"
+# shellcheck source=lib/wrapper_opts.sh
+source "$_GUARD_DIR/lib/wrapper_opts.sh"
 # shellcheck source=lib/command_name.sh
 source "$_GUARD_DIR/lib/command_name.sh"
 # shellcheck source=lib/paths.sh

--- a/hooks/lib/command_name.sh
+++ b/hooks/lib/command_name.sh
@@ -10,38 +10,6 @@
 # command_name_is reads a CMD variable from its caller's dynamic
 # scope; other functions are pure.
 
-# --- Per-wrapper list of options that consume the NEXT token ---
-# Mirrors _sf_wrapper_opts_with_val in subcmd_flags.sh and
-# _rd_wrapper_opts_with_val in remote_dispatch.sh. The three lists
-# are kept in sync but live in separate modules because each module
-# walks its own token array (`local toks` here, module-level
-# `_SF_TOKS` / `_RD_TOKS` elsewhere) — sharing one helper would need
-# bash 4 nameref support which macOS bash 3.2 lacks. See the
-# comment in _sf_find_verb_idx for the bypass shape and section 41
-# of tests/test_bypass_reproducers_flags.sh for the reproducers.
-_cn_wrapper_opts_with_val() {
-  # Only flags that actually take a value go in this list; value-less
-  # flags (`-A`, `-k`, `-K`, `-E`, `-H`, `-i`, `-l`, `-n`, `-P`, `-S`,
-  # `-s`, `-V`, `-v`, `-b`, `-e`; `--askpass`, `--background`,
-  # `--preserve-env`, `--edit`, `--set-home`, `--login`,
-  # `--remove-timestamp`, `--reset-timestamp`, `--list`,
-  # `--non-interactive`, `--preserve-groups`, `--stdin`, `--shell`,
-  # `--version`, `--validate`) fall through to the generic `-*`
-  # branch (consume one token). Mis-listing a value-less flag here
-  # would skip the verb (`sudo -A install ...` -> `install` consumed
-  # as the value of `-A`), reopening the original bypass — Codex
-  # round-1 P1 on PR #24.
-  case "$1" in
-    sudo) printf -- '-a -c -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --login-class --other-user --prompt --role --type --user' ;;
-    env)  printf -- '-u -C -P --unset --chdir' ;;
-    timeout) printf -- '-k -s --kill-after --signal' ;;
-    nice) printf -- '-n --adjustment' ;;
-    ionice) printf -- '-c -n -p --class --classdata --pid' ;;
-    chrt) printf -- '-p --pid' ;;
-    *) ;;
-  esac
-}
-
 # --- Strip /bin/, /sbin/, /usr/bin/, /usr/sbin/, /usr/local/bin/ prefix ---
 _cn_strip_path_prefix() {
   local n="$1"
@@ -82,7 +50,7 @@ _cn_find_verb_idx() {
     # identifies `root` as the verb (Codex round-4 follow-up on
     # PR #23; same root cause as section 40's _sf_find_verb_idx fix).
     if [ -n "$last_wrapper" ]; then
-      local opts; opts=$(_cn_wrapper_opts_with_val "$last_wrapper")
+      local opts; opts=$(_wrapper_opts_with_val "$last_wrapper")
       if [ -n "$opts" ]; then
         case " $opts " in
           *" $t "*) i=$((i + 2)); continue ;;
@@ -360,7 +328,7 @@ _cn_is_sudo_shell_opener() {
     t=$(strip_quotes "$raw")
 
     if [ -n "$last_wrapper" ]; then
-      local opts; opts=$(_cn_wrapper_opts_with_val "$last_wrapper")
+      local opts; opts=$(_wrapper_opts_with_val "$last_wrapper")
       if [ -n "$opts" ]; then
         case " $opts " in
           *" $t "*) i=$((i + 2)); continue ;;

--- a/hooks/lib/command_name.sh
+++ b/hooks/lib/command_name.sh
@@ -32,7 +32,7 @@ _cn_wrapper_opts_with_val() {
   # as the value of `-A`), reopening the original bypass — Codex
   # round-1 P1 on PR #24.
   case "$1" in
-    sudo) printf -- '-C -D -g -h -p -r -t -T -U -u --close-from --chdir --group --host --prompt --role --type --command-timeout --other-user --user --auth-type' ;;
+    sudo) printf -- '-a -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --other-user --prompt --role --type --user' ;;
     env)  printf -- '-u -C -P --unset --chdir' ;;
     timeout) printf -- '-k -s --kill-after --signal' ;;
     nice) printf -- '-n --adjustment' ;;
@@ -284,9 +284,9 @@ strip_sudo_wrapper_with_opts() {
     local raw="${toks[$i]}" t
     t=$(strip_quotes "$raw")
     case "$t" in
-      -C|-D|-g|-h|-p|-r|-t|-T|-U|-u)
+      -a|-C|-D|-g|-h|-p|-R|-r|-t|-T|-U|-u)
         i=$((i + 2)); continue ;;
-      --close-from|--chdir|--group|--host|--prompt|--role|--type|--command-timeout|--other-user|--user|--auth-type)
+      --auth-type|--chdir|--chroot|--close-from|--command-timeout|--group|--host|--other-user|--prompt|--role|--type|--user)
         i=$((i + 2)); continue ;;
       --*=*)
         i=$((i + 1)); continue ;;

--- a/hooks/lib/command_name.sh
+++ b/hooks/lib/command_name.sh
@@ -308,6 +308,128 @@ strip_sudo_wrapper_with_opts() {
   printf '%s' "$out"
 }
 
+# --- Detect a shell-opening sudo invocation ---
+# Returns 0 (success) iff the input describes a sudo invocation that
+# would open a privileged interactive shell with no command operand
+# to inspect. Recognised shapes:
+#
+#   sudo -i / sudo -s / sudo --login / sudo --shell      (standalone)
+#   sudo "-i" / sudo '-i' / sudo "--login"                (quoted —
+#                                                          tokenize_args
+#                                                          preserves quote
+#                                                          bytes; strip_quotes
+#                                                          unwraps them)
+#   sudo -ni / sudo -in / sudo -nis / sudo -A -ni         (clustered short
+#                                                          flags; sudo accepts
+#                                                          a cluster like -nis
+#                                                          for -n -i -s)
+#   <wrapper> [opts] sudo <any of the above>              (env / nice /
+#                                                          timeout / ionice /
+#                                                          chrt / nohup / time
+#                                                          / stdbuf / taskset /
+#                                                          command / builtin /
+#                                                          exec wrapping sudo)
+#
+# Returns 1 if no shell-opening sudo is detected — bare `sudo`,
+# `sudo -l` / `-V` / `-v`, `sudo -i extra-cmd` (cmd is what runs,
+# detectors walk it), and any non-sudo invocation.
+#
+# Called from check_single_command BEFORE the sudo strip so the
+# original wrapper + sudo + flag layout is still visible in the
+# token list. Reported by Codex review rounds 2–3 on PR #24.
+_cn_is_sudo_shell_opener() {
+  local cmd="$1"
+  local -a toks=()
+  while IFS= read -r t; do
+    [[ -z "$t" ]] && continue
+    toks+=("$t")
+  done < <(tokenize_args "$cmd")
+
+  local n=${#toks[@]}
+  [ "$n" -eq 0 ] && return 1
+
+  # Phase 1: walk past outer wrappers + their opt-with-value pairs.
+  # Mirrors _cn_find_verb_idx but stops on `sudo` (we're hunting
+  # specifically for sudo here, not for the verb in general). A non-
+  # wrapper non-flag token before `sudo` means the cmd isn't a
+  # sudo-shell-opener at all.
+  local i=0
+  local prev_was_timeout=0 last_wrapper=""
+  while [ "$i" -lt "$n" ]; do
+    local raw="${toks[$i]}" t
+    t=$(strip_quotes "$raw")
+
+    if [ -n "$last_wrapper" ]; then
+      local opts; opts=$(_cn_wrapper_opts_with_val "$last_wrapper")
+      if [ -n "$opts" ]; then
+        case " $opts " in
+          *" $t "*) i=$((i + 2)); continue ;;
+        esac
+      fi
+    fi
+
+    if [ "$prev_was_timeout" -eq 1 ]; then
+      prev_was_timeout=0
+      case "$t" in
+        [0-9]*|inf*) i=$((i + 1)); continue ;;
+      esac
+    fi
+    case "$t" in
+      timeout)
+        prev_was_timeout=1; last_wrapper="timeout"; i=$((i + 1)); continue ;;
+      env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
+        last_wrapper=$(_cn_strip_path_prefix "$t")
+        i=$((i + 1)); continue ;;
+      sudo)
+        break ;;
+    esac
+    case "$t" in
+      [A-Za-z_]*=*) i=$((i + 1)); continue ;;
+      -*) i=$((i + 1)); continue ;;
+    esac
+    return 1
+  done
+
+  # No `sudo` token found in the wrapper-walk segment.
+  [ "$i" -ge "$n" ] && return 1
+
+  # Phase 2: walk sudo's flags. Track whether we saw a shell-opening
+  # flag. A positional non-flag token after sudo means it has a real
+  # command (cmd is what runs even with -i/-s; detectors walk it).
+  i=$((i + 1))
+  local found_shell_opener=0
+  while [ "$i" -lt "$n" ]; do
+    local raw="${toks[$i]}" t
+    t=$(strip_quotes "$raw")
+    case "$t" in
+      -i|-s|--login|--shell)
+        found_shell_opener=1
+        i=$((i + 1)); continue ;;
+      -a|-c|-C|-D|-g|-h|-p|-R|-r|-t|-T|-U|-u)
+        i=$((i + 2)); continue ;;
+      --auth-type|--chdir|--chroot|--close-from|--command-timeout|--group|--host|--login-class|--other-user|--prompt|--role|--type|--user)
+        i=$((i + 2)); continue ;;
+      --*=*)
+        i=$((i + 1)); continue ;;
+      -[A-Za-z]*)
+        # Clustered short flags. Sudo accepts -nis as the cluster of
+        # -n -i -s; if the cluster body contains `i` or `s`, the
+        # invocation opens a shell. Long-form `--*=*` was already
+        # handled above; this branch only fires for short clusters.
+        local body="${t#-}"
+        case "$body" in
+          *i*|*s*) found_shell_opener=1 ;;
+        esac
+        i=$((i + 1)); continue ;;
+      *)
+        # Positional verb after sudo — detectors walk it normally.
+        return 1 ;;
+    esac
+  done
+
+  [ "$found_shell_opener" -eq 1 ]
+}
+
 # --- Detect shell/source tokens by basename (handles any absolute path) ---
 # `/opt/homebrew/bin/bash`, `/nix/store/.../bin/bash`, `/bin/bash` all
 # count as the shell `bash`. Without basename matching, the exec guard

--- a/hooks/lib/command_name.sh
+++ b/hooks/lib/command_name.sh
@@ -421,6 +421,14 @@ _cn_is_sudo_shell_opener() {
           *i*|*s*) found_shell_opener=1 ;;
         esac
         i=$((i + 1)); continue ;;
+      -*)
+        # Long-form valueless flags (`--preserve-env`, `--background`,
+        # `--non-interactive`, `--set-home`, `--remove-timestamp`, ...)
+        # don't match `--*=*` (no `=`) nor `-[A-Za-z]*` (start with
+        # `--`). Without this catch-all they fall through to `*` and
+        # the helper bails before seeing the trailing `-i`/`-s` —
+        # bypass: `sudo --preserve-env -i`. Mirrors strip_sudo_wrapper_with_opts.
+        i=$((i + 1)); continue ;;
       *)
         # Positional verb after sudo — detectors walk it normally.
         return 1 ;;

--- a/hooks/lib/command_name.sh
+++ b/hooks/lib/command_name.sh
@@ -20,8 +20,19 @@
 # comment in _sf_find_verb_idx for the bypass shape and section 41
 # of tests/test_bypass_reproducers_flags.sh for the reproducers.
 _cn_wrapper_opts_with_val() {
+  # Only flags that actually take a value go in this list; value-less
+  # flags (`-A`, `-k`, `-K`, `-E`, `-H`, `-i`, `-l`, `-n`, `-P`, `-S`,
+  # `-s`, `-V`, `-v`, `-b`, `-e`; `--askpass`, `--background`,
+  # `--preserve-env`, `--edit`, `--set-home`, `--login`,
+  # `--remove-timestamp`, `--reset-timestamp`, `--list`,
+  # `--non-interactive`, `--preserve-groups`, `--stdin`, `--shell`,
+  # `--version`, `--validate`) fall through to the generic `-*`
+  # branch (consume one token). Mis-listing a value-less flag here
+  # would skip the verb (`sudo -A install ...` -> `install` consumed
+  # as the value of `-A`), reopening the original bypass — Codex
+  # round-1 P1 on PR #24.
   case "$1" in
-    sudo) printf -- '-u -g -p -h -D -C -A -K -k -r -t' ;;
+    sudo) printf -- '-C -D -g -h -p -r -t -T -U -u --close-from --chdir --group --host --prompt --role --type --command-timeout --other-user --user --auth-type' ;;
     env)  printf -- '-u -C -P --unset --chdir' ;;
     timeout) printf -- '-k -s --kill-after --signal' ;;
     nice) printf -- '-n --adjustment' ;;
@@ -262,15 +273,20 @@ strip_sudo_wrapper_with_opts() {
   done < <(tokenize_args "$cmd")
 
   # toks[0] is "sudo" (or absent if cmd was bare "sudo"). Walk past
-  # sudo's option-with-value pairs and value-less flags.
+  # sudo's option-with-value pairs and value-less flags. The value-
+  # bearing list MUST exactly match sudo's "takes-an-argument" set;
+  # mis-classifying a value-less flag (`-A`, `-K`, `-k`,
+  # `--preserve-env`, `--login`, `--shell`, etc.) consumes the real
+  # verb as the flag's value and reopens the bypass this PR closes.
+  # Codex round-1 P1 on PR #24.
   local i=1 n=${#toks[@]}
   while [ $i -lt $n ]; do
     local raw="${toks[$i]}" t
     t=$(strip_quotes "$raw")
     case "$t" in
-      -u|-g|-p|-h|-D|-C|-A|-K|-k|-r|-t)
+      -C|-D|-g|-h|-p|-r|-t|-T|-U|-u)
         i=$((i + 2)); continue ;;
-      --user|--group|--prompt|--host|--chdir|--auth-type|--close-from|--login|--other-user|--preserve-env|--shell|--type)
+      --close-from|--chdir|--group|--host|--prompt|--role|--type|--command-timeout|--other-user|--user|--auth-type)
         i=$((i + 2)); continue ;;
       --*=*)
         i=$((i + 1)); continue ;;

--- a/hooks/lib/command_name.sh
+++ b/hooks/lib/command_name.sh
@@ -32,7 +32,7 @@ _cn_wrapper_opts_with_val() {
   # as the value of `-A`), reopening the original bypass — Codex
   # round-1 P1 on PR #24.
   case "$1" in
-    sudo) printf -- '-a -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --other-user --prompt --role --type --user' ;;
+    sudo) printf -- '-a -c -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --login-class --other-user --prompt --role --type --user' ;;
     env)  printf -- '-u -C -P --unset --chdir' ;;
     timeout) printf -- '-k -s --kill-after --signal' ;;
     nice) printf -- '-n --adjustment' ;;
@@ -284,9 +284,9 @@ strip_sudo_wrapper_with_opts() {
     local raw="${toks[$i]}" t
     t=$(strip_quotes "$raw")
     case "$t" in
-      -a|-C|-D|-g|-h|-p|-R|-r|-t|-T|-U|-u)
+      -a|-c|-C|-D|-g|-h|-p|-R|-r|-t|-T|-U|-u)
         i=$((i + 2)); continue ;;
-      --auth-type|--chdir|--chroot|--close-from|--command-timeout|--group|--host|--other-user|--prompt|--role|--type|--user)
+      --auth-type|--chdir|--chroot|--close-from|--command-timeout|--group|--host|--login-class|--other-user|--prompt|--role|--type|--user)
         i=$((i + 2)); continue ;;
       --*=*)
         i=$((i + 1)); continue ;;

--- a/hooks/lib/command_name.sh
+++ b/hooks/lib/command_name.sh
@@ -10,6 +10,98 @@
 # command_name_is reads a CMD variable from its caller's dynamic
 # scope; other functions are pure.
 
+# --- Per-wrapper list of options that consume the NEXT token ---
+# Mirrors _sf_wrapper_opts_with_val in subcmd_flags.sh and
+# _rd_wrapper_opts_with_val in remote_dispatch.sh. The three lists
+# are kept in sync but live in separate modules because each module
+# walks its own token array (`local toks` here, module-level
+# `_SF_TOKS` / `_RD_TOKS` elsewhere) — sharing one helper would need
+# bash 4 nameref support which macOS bash 3.2 lacks. See the
+# comment in _sf_find_verb_idx for the bypass shape and section 41
+# of tests/test_bypass_reproducers_flags.sh for the reproducers.
+_cn_wrapper_opts_with_val() {
+  case "$1" in
+    sudo) printf -- '-u -g -p -h -D -C -A -K -k -r -t' ;;
+    env)  printf -- '-u -C -P --unset --chdir' ;;
+    timeout) printf -- '-k -s --kill-after --signal' ;;
+    nice) printf -- '-n --adjustment' ;;
+    ionice) printf -- '-c -n -p --class --classdata --pid' ;;
+    chrt) printf -- '-p --pid' ;;
+    *) ;;
+  esac
+}
+
+# --- Strip /bin/, /sbin/, /usr/bin/, /usr/sbin/, /usr/local/bin/ prefix ---
+_cn_strip_path_prefix() {
+  local n="$1"
+  case "$n" in
+    /bin/*|/sbin/*|/usr/bin/*|/usr/sbin/*|/usr/local/bin/*) printf '%s' "${n##*/}" ;;
+    *) printf '%s' "$n" ;;
+  esac
+}
+
+# --- Find verb-token index in a tokens array, skipping wrappers / opts / VAR=val ---
+# Caller fills the local-scope `toks` array before calling. Returns the
+# 0-based index of the first non-wrapper / non-flag / non-VAR=val token,
+# or -1 if no such token exists. Skip rules:
+#
+#   - Recognised wrappers (sudo / env / nice / nohup / time / stdbuf /
+#     ionice / chrt / taskset / command / builtin / exec / timeout /
+#     /bin/env / /usr/bin/env) advance one position; the next iteration
+#     also skips a per-wrapper option-with-value pair (e.g. `-u USER`
+#     for sudo / env, `-k DUR` for timeout) when the value would
+#     otherwise be mis-identified as the verb.
+#   - `timeout` additionally takes a duration operand (`5`, `5s`,
+#     `1.5h`, `infinity`) which is consumed as a single positional.
+#   - `[A-Za-z_]*=*` (env-var prefix) and bare `-*` flags are skipped
+#     one at a time.
+#
+# Reads the caller's `toks` array via dynamic scoping (bash `local`
+# semantics); CALLERS MUST declare `local -a toks=()` before invoking.
+_cn_find_verb_idx() {
+  local i=0 n=${#toks[@]}
+  local prev_was_timeout=0 last_wrapper=""
+  while [ $i -lt $n ]; do
+    local raw="${toks[$i]}" t
+    t=$(strip_quotes "$raw")
+
+    # Wrapper opt-with-value: if the previous wrapper had options
+    # that consume the next token, advance past both the flag and
+    # its value. Without this, `sudo -u root install …` mis-
+    # identifies `root` as the verb (Codex round-4 follow-up on
+    # PR #23; same root cause as section 40's _sf_find_verb_idx fix).
+    if [ -n "$last_wrapper" ]; then
+      local opts; opts=$(_cn_wrapper_opts_with_val "$last_wrapper")
+      if [ -n "$opts" ]; then
+        case " $opts " in
+          *" $t "*) i=$((i + 2)); continue ;;
+        esac
+      fi
+    fi
+
+    if [ $prev_was_timeout -eq 1 ]; then
+      prev_was_timeout=0
+      case "$t" in
+        [0-9]*|inf*) i=$((i + 1)); continue ;;
+      esac
+    fi
+    case "$t" in
+      timeout)
+        prev_was_timeout=1; last_wrapper="timeout"; i=$((i + 1)); continue ;;
+      sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
+        last_wrapper=$(_cn_strip_path_prefix "$t")
+        i=$((i + 1)); continue ;;
+    esac
+    case "$t" in
+      [A-Za-z_]*=*) i=$((i + 1)); continue ;;
+      -*) i=$((i + 1)); continue ;;
+    esac
+    printf '%d' "$i"
+    return
+  done
+  printf -- '-1'
+}
+
 # --- Strip a binary path prefix from the command-name token ---
 # Strip a binary path prefix (/bin/, /sbin/, /usr/bin/, /usr/sbin/,
 # /usr/local/bin/) from the command-name token of CMD only — not from
@@ -32,35 +124,9 @@ strip_command_name_prefix() {
     toks+=("$t")
   done < <(tokenize_args "$cmd")
 
-  local idx=-1 i
-  local prev_was_timeout=0
-  for i in "${!toks[@]}"; do
-    local raw="${toks[$i]}"
-    local t
-    t=$(strip_quotes "$raw")
-    # `timeout` takes a duration operand (e.g. `timeout 5 cmd`,
-    # `timeout 1.5s cmd`); skip one extra token after it.
-    if [ $prev_was_timeout -eq 1 ]; then
-      prev_was_timeout=0
-      case "$t" in
-        [0-9]*) continue ;;
-      esac
-    fi
-    case "$t" in
-      timeout)
-        prev_was_timeout=1; continue ;;
-      sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
-        continue ;;
-    esac
-    case "$t" in
-      [A-Za-z_]*=*) continue ;;
-      -*) continue ;;
-    esac
-    idx=$i
-    break
-  done
-
-  [[ $idx -lt 0 ]] && { printf '%s' "$cmd"; return; }
+  local idx
+  idx=$(_cn_find_verb_idx)
+  [ "$idx" -lt 0 ] && { printf '%s' "$cmd"; return; }
 
   local first
   first=$(strip_quotes "${toks[$idx]}")
@@ -100,32 +166,9 @@ strip_command_name_quotes() {
     toks+=("$t")
   done < <(tokenize_args "$cmd")
 
-  local idx=-1 i prev_was_timeout=0
-  for i in "${!toks[@]}"; do
-    local raw="${toks[$i]}"
-    local t
-    t=$(strip_quotes "$raw")
-    if [ $prev_was_timeout -eq 1 ]; then
-      prev_was_timeout=0
-      case "$t" in
-        [0-9]*) continue ;;
-      esac
-    fi
-    case "$t" in
-      timeout)
-        prev_was_timeout=1; continue ;;
-      sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
-        continue ;;
-    esac
-    case "$t" in
-      [A-Za-z_]*=*) continue ;;
-      -*) continue ;;
-    esac
-    idx=$i
-    break
-  done
-
-  [[ $idx -lt 0 ]] && { printf '%s' "$cmd"; return; }
+  local idx
+  idx=$(_cn_find_verb_idx)
+  [ "$idx" -lt 0 ] && { printf '%s' "$cmd"; return; }
 
   local raw="${toks[$idx]}"
   # Only rewrite when the raw token is itself surrounded by matching
@@ -154,7 +197,8 @@ command_name_is() {
   # Return 0 iff the post-wrapper command-name token of $CMD equals $1.
   # Walks $CMD tokens using the same rules as strip_command_name_prefix:
   # skip `timeout <dur>`, sudo/env/nice/nohup/time/stdbuf/ionice/chrt/
-  # taskset/command/builtin/exec wrappers, VAR=val environment prefixes
+  # taskset/command/builtin/exec wrappers (and their option-with-value
+  # pairs like `-u USER`, `-k DUR`), VAR=val environment prefixes
   # and -flag tokens. Any /bin/, /sbin/, /usr/bin/, /usr/sbin/,
   # /usr/local/bin/ prefix on the command-name token is stripped before
   # comparison, so `/usr/bin/install` is recognised as `install`.
@@ -175,33 +219,77 @@ command_name_is() {
     [[ -z "$t" ]] && continue
     toks+=("$t")
   done < <(tokenize_args "$CMD")
-  local i prev_was_timeout=0
-  for i in "${!toks[@]}"; do
+
+  local idx
+  idx=$(_cn_find_verb_idx)
+  [ "$idx" -lt 0 ] && return 1
+
+  local t
+  t=$(strip_quotes "${toks[$idx]}")
+  t=$(_cn_strip_path_prefix "$t")
+  [ "$t" = "$target" ]
+}
+
+# --- Strip leading `sudo` plus its option-with-value pairs from CMD ---
+# Replaces the literal `${CMD#sudo }` strip in check_single_command.
+# Without opt-stripping, `sudo -u root install …` collapsed to
+# `-u root install …` — the orphaned `-u root` then mis-led the
+# wrapper-walk in strip_command_name_prefix / strip_command_name_quotes /
+# command_name_is (sudo is no longer in the token list to anchor to,
+# so `root` was treated as the verb). env / nice / ionice / timeout
+# are NOT literal-stripped, so the per-wrapper opt-skip in
+# _cn_find_verb_idx handles those wrappers in place.
+#
+# Walks past sudo + its option-with-value pairs (-u USER, --user=USER,
+# -g GROUP, etc.), value-less short and long flags (-n, --background,
+# etc.), and emits the rest of CMD starting at the first positional.
+# tokenize_args preserves quote bytes, so reconstruction with single-
+# space joins keeps quoted operands intact (whitespace inside the
+# command is normalised in the next pass anyway — guard.sh:280).
+#
+# Reported by Codex review round-4 on PR #23 (out-of-scope follow-up).
+strip_sudo_wrapper_with_opts() {
+  local cmd="$1"
+  case "$cmd" in
+    sudo|sudo[[:space:]]*) ;;
+    *) printf '%s' "$cmd"; return ;;
+  esac
+
+  local -a toks=()
+  while IFS= read -r t; do
+    [[ -z "$t" ]] && continue
+    toks+=("$t")
+  done < <(tokenize_args "$cmd")
+
+  # toks[0] is "sudo" (or absent if cmd was bare "sudo"). Walk past
+  # sudo's option-with-value pairs and value-less flags.
+  local i=1 n=${#toks[@]}
+  while [ $i -lt $n ]; do
     local raw="${toks[$i]}" t
     t=$(strip_quotes "$raw")
-    if [ $prev_was_timeout -eq 1 ]; then
-      prev_was_timeout=0
-      case "$t" in
-        [0-9]*) continue ;;
-      esac
-    fi
     case "$t" in
-      timeout)
-        prev_was_timeout=1; continue ;;
-      sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
-        continue ;;
+      -u|-g|-p|-h|-D|-C|-A|-K|-k|-r|-t)
+        i=$((i + 2)); continue ;;
+      --user|--group|--prompt|--host|--chdir|--auth-type|--close-from|--login|--other-user|--preserve-env|--shell|--type)
+        i=$((i + 2)); continue ;;
+      --*=*)
+        i=$((i + 1)); continue ;;
+      -*)
+        i=$((i + 1)); continue ;;
+      *) break ;;
     esac
-    case "$t" in
-      [A-Za-z_]*=*) continue ;;
-      -*) continue ;;
-    esac
-    case "$t" in
-      /bin/*|/sbin/*|/usr/bin/*|/usr/sbin/*|/usr/local/bin/*) t="${t##*/}" ;;
-    esac
-    [ "$t" = "$target" ]
-    return
   done
-  return 1
+
+  local out=""
+  while [ $i -lt $n ]; do
+    if [ -z "$out" ]; then
+      out="${toks[$i]}"
+    else
+      out="$out ${toks[$i]}"
+    fi
+    i=$((i + 1))
+  done
+  printf '%s' "$out"
 }
 
 # --- Detect shell/source tokens by basename (handles any absolute path) ---

--- a/hooks/lib/remote_dispatch.sh
+++ b/hooks/lib/remote_dispatch.sh
@@ -95,7 +95,7 @@ _rd_wrapper_opts_with_val() {
   # `sudo -A docker exec ...`), letting the local-fs walkers
   # over-block legit foreign-fs commands. Codex round-1 P1 on PR #24.
   case "$1" in
-    sudo) printf -- '-a -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --other-user --prompt --role --type --user' ;;
+    sudo) printf -- '-a -c -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --login-class --other-user --prompt --role --type --user' ;;
     env)  printf -- '-u -C -P --unset --chdir' ;;
     timeout) printf -- '-k -s --kill-after --signal' ;;
     nice) printf -- '-n --adjustment' ;;

--- a/hooks/lib/remote_dispatch.sh
+++ b/hooks/lib/remote_dispatch.sh
@@ -95,7 +95,7 @@ _rd_wrapper_opts_with_val() {
   # `sudo -A docker exec ...`), letting the local-fs walkers
   # over-block legit foreign-fs commands. Codex round-1 P1 on PR #24.
   case "$1" in
-    sudo) printf -- '-C -D -g -h -p -r -t -T -U -u --close-from --chdir --group --host --prompt --role --type --command-timeout --other-user --user --auth-type' ;;
+    sudo) printf -- '-a -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --other-user --prompt --role --type --user' ;;
     env)  printf -- '-u -C -P --unset --chdir' ;;
     timeout) printf -- '-k -s --kill-after --signal' ;;
     nice) printf -- '-n --adjustment' ;;

--- a/hooks/lib/remote_dispatch.sh
+++ b/hooks/lib/remote_dispatch.sh
@@ -79,32 +79,74 @@ _rd_is_remote_target_operand() {
   return 1
 }
 
+# --- Per-wrapper list of options that consume the NEXT token ---
+# Mirrors _sf_wrapper_opts_with_val (subcmd_flags.sh) and
+# _cn_wrapper_opts_with_val (command_name.sh). The three lists are
+# kept in sync but live in separate modules because each walks its
+# own token array — sharing a single helper would need bash 4
+# nameref support which macOS bash 3.2 lacks. See section 42 of
+# tests/test_bypass_reproducers_flags.sh for the over-block
+# scenarios this guards against.
+_rd_wrapper_opts_with_val() {
+  case "$1" in
+    sudo) printf -- '-u -g -p -h -D -C -A -K -k -r -t' ;;
+    env)  printf -- '-u -C -P --unset --chdir' ;;
+    timeout) printf -- '-k -s --kill-after --signal' ;;
+    nice) printf -- '-n --adjustment' ;;
+    ionice) printf -- '-c -n -p --class --classdata --pid' ;;
+    chrt) printf -- '-p --pid' ;;
+    *) ;;
+  esac
+}
+
 # --- Find command-name token index, skipping wrappers/flags/VAR=val ---
 # Mirrors the wrapper-skip rules used by strip_command_name_prefix and
 # command_name_is. Reads from the module-local _RD_TOKS array (set by
 # rewrite_remote_dispatch before calling). Returns -1 if no command-name
 # found. Uses a global rather than `local -n` because macOS ships
 # bash 3.2 which lacks nameref support.
+#
+# Also skips a per-wrapper option-with-value pair (e.g. `-u USER` for
+# sudo/env, `-k DUR` for timeout) when the value would otherwise be
+# mis-identified as the verb. Without this, `env -u FOO docker exec
+# ctr rm -rf /` mis-identified `FOO` as the verb (verb_pair="FOO
+# docker"), `rewrite_remote_dispatch` returned the cmd unchanged, and
+# the bare rm walker over-blocked the foreign-fs `rm -rf /` (which
+# actually runs inside the container, not on host). Same root cause
+# as section 40 (subcmd_flags.sh) and section 41 (command_name.sh);
+# Codex round-4 follow-up on PR #23.
 _rd_find_verb_idx() {
-  local i prev_was_timeout=0
-  for i in "${!_RD_TOKS[@]}"; do
+  local i=0 n=${#_RD_TOKS[@]}
+  local prev_was_timeout=0 last_wrapper=""
+  while [ $i -lt $n ]; do
     local raw="${_RD_TOKS[$i]}" t
     t=$(strip_quotes "$raw")
+
+    if [ -n "$last_wrapper" ]; then
+      local opts; opts=$(_rd_wrapper_opts_with_val "$last_wrapper")
+      if [ -n "$opts" ]; then
+        case " $opts " in
+          *" $t "*) i=$((i + 2)); continue ;;
+        esac
+      fi
+    fi
+
     if [ $prev_was_timeout -eq 1 ]; then
       prev_was_timeout=0
       case "$t" in
-        [0-9]*) continue ;;
+        [0-9]*|inf*) i=$((i + 1)); continue ;;
       esac
     fi
     case "$t" in
       timeout)
-        prev_was_timeout=1; continue ;;
+        prev_was_timeout=1; last_wrapper="timeout"; i=$((i + 1)); continue ;;
       sudo|env|/bin/env|/usr/bin/env|nice|nohup|time|stdbuf|ionice|chrt|taskset|command|builtin|exec)
-        continue ;;
+        last_wrapper=$(_rd_strip_path_prefix "$t")
+        i=$((i + 1)); continue ;;
     esac
     case "$t" in
-      [A-Za-z_]*=*) continue ;;
-      -*) continue ;;
+      [A-Za-z_]*=*) i=$((i + 1)); continue ;;
+      -*) i=$((i + 1)); continue ;;
     esac
     printf '%d' "$i"
     return

--- a/hooks/lib/remote_dispatch.sh
+++ b/hooks/lib/remote_dispatch.sh
@@ -79,32 +79,6 @@ _rd_is_remote_target_operand() {
   return 1
 }
 
-# --- Per-wrapper list of options that consume the NEXT token ---
-# Mirrors _sf_wrapper_opts_with_val (subcmd_flags.sh) and
-# _cn_wrapper_opts_with_val (command_name.sh). The three lists are
-# kept in sync but live in separate modules because each walks its
-# own token array — sharing a single helper would need bash 4
-# nameref support which macOS bash 3.2 lacks. See section 42 of
-# tests/test_bypass_reproducers_flags.sh for the over-block
-# scenarios this guards against.
-_rd_wrapper_opts_with_val() {
-  # Only flags that actually take a value go in this list — see the
-  # comment on _cn_wrapper_opts_with_val (command_name.sh) for the
-  # full classification rationale. Mis-listing a value-less sudo flag
-  # would mis-identify the verb under remote-dispatch wrappers (e.g.
-  # `sudo -A docker exec ...`), letting the local-fs walkers
-  # over-block legit foreign-fs commands. Codex round-1 P1 on PR #24.
-  case "$1" in
-    sudo) printf -- '-a -c -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --login-class --other-user --prompt --role --type --user' ;;
-    env)  printf -- '-u -C -P --unset --chdir' ;;
-    timeout) printf -- '-k -s --kill-after --signal' ;;
-    nice) printf -- '-n --adjustment' ;;
-    ionice) printf -- '-c -n -p --class --classdata --pid' ;;
-    chrt) printf -- '-p --pid' ;;
-    *) ;;
-  esac
-}
-
 # --- Find command-name token index, skipping wrappers/flags/VAR=val ---
 # Mirrors the wrapper-skip rules used by strip_command_name_prefix and
 # command_name_is. Reads from the module-local _RD_TOKS array (set by
@@ -129,7 +103,7 @@ _rd_find_verb_idx() {
     t=$(strip_quotes "$raw")
 
     if [ -n "$last_wrapper" ]; then
-      local opts; opts=$(_rd_wrapper_opts_with_val "$last_wrapper")
+      local opts; opts=$(_wrapper_opts_with_val "$last_wrapper")
       if [ -n "$opts" ]; then
         case " $opts " in
           *" $t "*) i=$((i + 2)); continue ;;

--- a/hooks/lib/remote_dispatch.sh
+++ b/hooks/lib/remote_dispatch.sh
@@ -88,8 +88,14 @@ _rd_is_remote_target_operand() {
 # tests/test_bypass_reproducers_flags.sh for the over-block
 # scenarios this guards against.
 _rd_wrapper_opts_with_val() {
+  # Only flags that actually take a value go in this list — see the
+  # comment on _cn_wrapper_opts_with_val (command_name.sh) for the
+  # full classification rationale. Mis-listing a value-less sudo flag
+  # would mis-identify the verb under remote-dispatch wrappers (e.g.
+  # `sudo -A docker exec ...`), letting the local-fs walkers
+  # over-block legit foreign-fs commands. Codex round-1 P1 on PR #24.
   case "$1" in
-    sudo) printf -- '-u -g -p -h -D -C -A -K -k -r -t' ;;
+    sudo) printf -- '-C -D -g -h -p -r -t -T -U -u --close-from --chdir --group --host --prompt --role --type --command-timeout --other-user --user --auth-type' ;;
     env)  printf -- '-u -C -P --unset --chdir' ;;
     timeout) printf -- '-k -s --kill-after --signal' ;;
     nice) printf -- '-n --adjustment' ;;

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -81,7 +81,7 @@ _sf_wrapper_opts_with_val() {
   # (`-A`, `-K`, `-k`, `--preserve-env`, ...) skips the real verb,
   # reopening the section-40 bypass. Codex round-1 P1 on PR #24.
   case "$1" in
-    sudo) printf -- '-C -D -g -h -p -r -t -T -U -u --close-from --chdir --group --host --prompt --role --type --command-timeout --other-user --user --auth-type' ;;
+    sudo) printf -- '-a -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --other-user --prompt --role --type --user' ;;
     env)  printf -- '-u -C -P --unset --chdir' ;;
     timeout) printf -- '-k -s --kill-after --signal' ;;
     nice) printf -- '-n --adjustment' ;;

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -66,31 +66,6 @@ declare -a SUBCMD_FLAG_SINKS=(
   "git|-c||git-config|^(core\\.(sshCommand|editor|pager|askPass|fsmonitor)|pager\\..+|sequence\\.editor|gpg\\.(program|ssh\\.program|openpgp\\.program|x509\\.program)|credential\\.helper|diff\\.(external|.+\\.(command|textconv))|mergetool\\..+\\.cmd|merge\\..+\\.driver|filter\\..+\\.(clean|smudge|process)|uploadpack\\.packObjectsHook|submodule\\..+\\.update|alias\\..+)$"
 )
 
-# --- Per-wrapper list of options that consume the NEXT token ---
-# Some wrappers take option-with-value flags before the real verb
-# (`sudo -u root cmd`, `env -u VAR cmd`, `timeout -k 5 10 cmd`).
-# Without skipping the value too, the verb-finder mis-identifies the
-# value as the verb (e.g. `root` instead of `cmd`), so the sink
-# table never matches. Reported by Copilot review on PR #23
-# (guard.sh:897). Returns a space-separated list on stdout; empty
-# for unknown wrappers.
-_sf_wrapper_opts_with_val() {
-  # Only flags that actually take a value go in this list — see the
-  # comment on _cn_wrapper_opts_with_val (command_name.sh) for the
-  # full classification rationale. Mis-listing a value-less sudo flag
-  # (`-A`, `-K`, `-k`, `--preserve-env`, ...) skips the real verb,
-  # reopening the section-40 bypass. Codex round-1 P1 on PR #24.
-  case "$1" in
-    sudo) printf -- '-a -c -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --login-class --other-user --prompt --role --type --user' ;;
-    env)  printf -- '-u -C -P --unset --chdir' ;;
-    timeout) printf -- '-k -s --kill-after --signal' ;;
-    nice) printf -- '-n --adjustment' ;;
-    ionice) printf -- '-c -n -p --class --classdata --pid' ;;
-    chrt) printf -- '-p --pid' ;;
-    *) ;;
-  esac
-}
-
 # --- Find verb token index, skipping wrappers / VAR=val / flags ---
 # Mirrors _rd_find_verb_idx in remote_dispatch.sh. Reads from the
 # module-local _SF_TOKS array. Uses a global rather than `local -n`
@@ -106,7 +81,7 @@ _sf_find_verb_idx() {
     # that consume the next token, advance past both the flag and
     # its value (Copilot review on PR #23, guard.sh:897).
     if [ -n "$last_wrapper" ]; then
-      local opts; opts=$(_sf_wrapper_opts_with_val "$last_wrapper")
+      local opts; opts=$(_wrapper_opts_with_val "$last_wrapper")
       if [ -n "$opts" ]; then
         case " $opts " in
           *" $t "*) i=$((i + 2)); continue ;;

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -81,7 +81,7 @@ _sf_wrapper_opts_with_val() {
   # (`-A`, `-K`, `-k`, `--preserve-env`, ...) skips the real verb,
   # reopening the section-40 bypass. Codex round-1 P1 on PR #24.
   case "$1" in
-    sudo) printf -- '-a -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --other-user --prompt --role --type --user' ;;
+    sudo) printf -- '-a -c -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --login-class --other-user --prompt --role --type --user' ;;
     env)  printf -- '-u -C -P --unset --chdir' ;;
     timeout) printf -- '-k -s --kill-after --signal' ;;
     nice) printf -- '-n --adjustment' ;;

--- a/hooks/lib/subcmd_flags.sh
+++ b/hooks/lib/subcmd_flags.sh
@@ -75,8 +75,13 @@ declare -a SUBCMD_FLAG_SINKS=(
 # (guard.sh:897). Returns a space-separated list on stdout; empty
 # for unknown wrappers.
 _sf_wrapper_opts_with_val() {
+  # Only flags that actually take a value go in this list — see the
+  # comment on _cn_wrapper_opts_with_val (command_name.sh) for the
+  # full classification rationale. Mis-listing a value-less sudo flag
+  # (`-A`, `-K`, `-k`, `--preserve-env`, ...) skips the real verb,
+  # reopening the section-40 bypass. Codex round-1 P1 on PR #24.
   case "$1" in
-    sudo) printf -- '-u -g -p -h -D -C -A -K -k -r -t' ;;
+    sudo) printf -- '-C -D -g -h -p -r -t -T -U -u --close-from --chdir --group --host --prompt --role --type --command-timeout --other-user --user --auth-type' ;;
     env)  printf -- '-u -C -P --unset --chdir' ;;
     timeout) printf -- '-k -s --kill-after --signal' ;;
     nice) printf -- '-n --adjustment' ;;

--- a/hooks/lib/wrapper_opts.sh
+++ b/hooks/lib/wrapper_opts.sh
@@ -1,0 +1,35 @@
+# shellcheck shell=bash
+# Per-wrapper list of options that consume the NEXT token.
+#
+# Some wrappers take option-with-value flags before the real verb
+# (`sudo -u root cmd`, `env -u VAR cmd`, `timeout -k 5 10 cmd`).
+# Without skipping the value too, the verb-finder mis-identifies the
+# value as the verb (e.g. `root` instead of `cmd`), so downstream
+# walkers (sink table / install detector / remote-dispatch
+# neutraliser) never match. Reported by Copilot review on PR #23
+# (guard.sh:897); propagated to command_name.sh / remote_dispatch.sh
+# in PR #24 sec 41 / 42.
+#
+# Returns a space-separated list on stdout; empty for unknown
+# wrappers. Callers wrap the result in ` ` so a `case` glob like
+# `*" $t "*` matches whole tokens only.
+#
+# IMPORTANT: only flags that actually take a value go here. Value-
+# less flags (sudo `-A`, `-k`, `-K`, `-E`, `-H`, `-i`, `-l`, `-n`,
+# `-P`, `-S`, `-s`, `-V`, `-v`, `-b`, `-e`; long forms `--askpass`,
+# `--background`, `--preserve-env`, `--login`, `--shell`, ...) MUST
+# fall through to the caller's generic `-*` / `-[A-Za-z]*` branch
+# (consume one token). Mis-listing a value-less flag skips the real
+# verb and reopens the section-40 bypass — Codex round-1 P1 on PR
+# #24.
+_wrapper_opts_with_val() {
+  case "$1" in
+    sudo) printf -- '-a -c -C -D -g -h -p -R -r -t -T -U -u --auth-type --chdir --chroot --close-from --command-timeout --group --host --login-class --other-user --prompt --role --type --user' ;;
+    env)  printf -- '-u -C -P --unset --chdir' ;;
+    timeout) printf -- '-k -s --kill-after --signal' ;;
+    nice) printf -- '-n --adjustment' ;;
+    ionice) printf -- '-c -n -p --class --classdata --pid' ;;
+    chrt) printf -- '-p --pid' ;;
+    *) ;;
+  esac
+}

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -872,3 +872,61 @@ expect_blocked "sudo -C 100 install ... /etc/owned (-C close-from takes value)" 
   "sudo -C 100 install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
 
 echo ""
+
+# ============================================================
+# 44. Missing sudo value-bearing flags — `-a` / `-R` / `--chroot`
+# ------------------------------------------------------------
+# Round-1 fixed `-A` / `-K` / `-k` / `--preserve-env` mis-listed as
+# value-bearing. Round-2 found the OPPOSITE error in the same set:
+# three sudo flags that DO take a value were missing from the
+# value-bearing list. Per `man sudo` (1.9.x):
+#
+#   -a type  / --auth-type=type   BSD authentication type
+#   -R dir   / --chroot=dir       chroot directory before running cmd
+#   -T sec   / --command-timeout  (already in list)
+#
+# Without these in the value-bearing branch, `sudo -a bsdauth install
+# ...` was walked as `bsdauth install ...` — the verb-finder treated
+# `bsdauth` as the verb and the install detector never fired. Same
+# bypass shape as round-1 but for a complementary subset of sudo's
+# option grammar.
+#
+# Fix: add `-a`, `-R`, `--chroot` to all four sites (three module
+# tables — _cn_ / _sf_ / _rd_ — plus strip_sudo_wrapper_with_opts).
+#
+# Reported by Codex review round-2 on PR #24 (P1).
+# ============================================================
+echo "--- 44. missing sudo value-bearing flags (-a / -R / --chroot) ---"
+
+# command_name_is install bypass.
+expect_blocked "sudo -a bsdauth install ... /etc/owned" \
+  "sudo -a bsdauth install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+expect_blocked "sudo -R / install ... /etc/owned" \
+  "sudo -R / install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+expect_blocked "sudo --chroot / install ... /etc/owned" \
+  "sudo --chroot / install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+# strip_command_name_prefix bypass on /bin/rm.
+expect_blocked "sudo -a bsdauth /bin/rm /etc/passwd_test" \
+  "sudo -a bsdauth /bin/rm /etc/passwd_test"
+
+expect_blocked "sudo -R / /bin/rm /etc/passwd_test" \
+  "sudo -R / /bin/rm /etc/passwd_test"
+
+# Subcmd-flag exec-sink bypass.
+expect_blocked "sudo -a bsdauth tar --to-command='rm /etc/x'" \
+  "sudo -a bsdauth tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+# True-negatives: legit sudo with these flags + read must remain ALLOWED.
+expect_allowed "sudo -a bsdauth cat (read in-project)" \
+  "sudo -a bsdauth cat $PROJECT/CHANGELOG.md"
+
+expect_allowed "sudo -R / cat (chroot + read)" \
+  "sudo -R / cat $PROJECT/CHANGELOG.md"
+
+expect_allowed "sudo --chroot / ls (long-form chroot + benign)" \
+  "sudo --chroot / ls $PROJECT"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -999,3 +999,42 @@ expect_allowed "sudo --version (long-form -V)" \
   "sudo --version"
 
 echo ""
+
+# ============================================================
+# 46. Missing sudo value-bearing flag — `-c` / `--login-class`
+# ------------------------------------------------------------
+# Round-2 added `-a` / `-R` / `--chroot`. Round-3 found one more
+# value-bearing sudo flag still absent from the list. Per `man sudo`
+# (1.9.x):
+#
+#   -c class / --login-class=class   BSD login class
+#
+# Without it in the value-bearing branch, `sudo -c staff install
+# ... /etc/owned` was walked as `staff install ...` — the verb-
+# finder treated `staff` as the verb. Same bypass shape as round-2
+# section 44 (-a / -R / --chroot), one missing flag.
+#
+# Reported by Codex review round-3 on PR #24 (P1).
+# ============================================================
+echo "--- 46. missing sudo value-bearing flag (-c / --login-class) ---"
+
+expect_blocked "sudo -c staff install ... /etc/owned" \
+  "sudo -c staff install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+expect_blocked "sudo --login-class staff install ... /etc/owned" \
+  "sudo --login-class staff install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+expect_blocked "sudo -c staff /bin/rm /etc/passwd_test" \
+  "sudo -c staff /bin/rm /etc/passwd_test"
+
+expect_blocked "sudo -c staff tar --to-command='rm /etc/x'" \
+  "sudo -c staff tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+# True-negatives: legit sudo with -c + read must remain ALLOWED.
+expect_allowed "sudo -c staff cat (login-class + read)" \
+  "sudo -c staff cat $PROJECT/CHANGELOG.md"
+
+expect_allowed "sudo --login-class staff ls (long-form + benign)" \
+  "sudo --login-class staff ls $PROJECT"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -1038,3 +1038,108 @@ expect_allowed "sudo --login-class staff ls (long-form + benign)" \
   "sudo --login-class staff ls $PROJECT"
 
 echo ""
+
+# ============================================================
+# 47. Shell-opening sudo: clustered / quoted / wrapper-prefixed
+# ------------------------------------------------------------
+# Round-2 section 45 added an empty-CMD check that blocked the
+# standalone forms `sudo -i` / `-s` / `--login` / `--shell`. Round-3
+# found three shapes that still slipped past:
+#
+#   (a) Clustered short flags ending in `i` or `s`:
+#       sudo -ni, sudo -in, sudo -A -ni, sudo -nis
+#       (sudo accepts -nis as the cluster of -n / -i / -s)
+#
+#   (b) Quoted standalone forms that the regex didn't strip:
+#       sudo "-i", sudo '-i'
+#
+#   (c) Outer wrapper around sudo:
+#       env -u FOO sudo -i
+#       nice -n 10 sudo -s
+#       timeout -k 5 10 sudo -i
+#       (the empty-CMD branch never fires because CMD doesn't start
+#        with sudo, so strip_sudo_wrapper_with_opts is a no-op and
+#        CMD stays non-empty.)
+#
+# Fix: replace the regex-based empty-CMD check with a proper
+# `_cn_is_sudo_shell_opener` helper that:
+#   1. Tokenises _CMD_PRE_STRIP and walks past outer wrappers + opts
+#      (env / nice / nohup / time / stdbuf / ionice / chrt / taskset
+#      / command / builtin / exec / timeout) using the same logic as
+#      _cn_find_verb_idx.
+#   2. When `sudo` is reached, walks sudo's flags consuming opt-with-
+#      value pairs correctly. Standalone `-i`/`-s`/`--login`/`--shell`
+#      AND clustered short flags whose body contains `i` or `s` set
+#      found_shell_opener=1.
+#   3. Returns 0 (shell-opener) iff a shell-opening flag was seen
+#      AND no positional verb followed (sudo with a real command
+#      runs the cmd via shell — that's still walked by detectors).
+# Called before the sudo strip so it sees the original wrapper +
+# sudo + flag layout.
+#
+# Reported by Codex review round-3 on PR #24 (P2).
+# ============================================================
+echo "--- 47. shell-opening sudo: clustered / quoted / wrapper-prefixed ---"
+
+# (a) Clustered short flags.
+expect_blocked "sudo -ni (cluster -n + -i)" \
+  "sudo -ni"
+
+expect_blocked "sudo -in (cluster reverse order)" \
+  "sudo -in"
+
+expect_blocked "sudo -A -ni (after -A askpass valueless)" \
+  "sudo -A -ni"
+
+expect_blocked "sudo -nis (cluster -n + -i + -s)" \
+  "sudo -nis"
+
+expect_blocked "sudo -ns (cluster -n + -s)" \
+  "sudo -ns"
+
+# (b) Quoted standalone forms.
+expect_blocked 'sudo "-i" (double-quoted)' \
+  'sudo "-i"'
+
+expect_blocked "sudo '-i' (single-quoted)" \
+  "sudo '-i'"
+
+expect_blocked 'sudo "-s" (quoted -s)' \
+  'sudo "-s"'
+
+expect_blocked 'sudo "--login" (quoted long form)' \
+  'sudo "--login"'
+
+# (c) Outer wrapper around sudo.
+expect_blocked "env -u FOO sudo -i (env wrapper + sudo shell)" \
+  "env -u FOO sudo -i"
+
+expect_blocked "env -u FOO sudo -ni (env wrapper + cluster)" \
+  "env -u FOO sudo -ni"
+
+expect_blocked "nice -n 10 sudo -s (nice wrapper + sudo shell)" \
+  "nice -n 10 sudo -s"
+
+expect_blocked "timeout -k 5 10 sudo -i (timeout wrapper + sudo shell)" \
+  "timeout -k 5 10 sudo -i"
+
+expect_blocked "ionice -c 3 sudo --login (ionice + long-form)" \
+  "ionice -c 3 sudo --login"
+
+# True-negatives: sudo with a positional verb (NOT shell-opener — cmd is
+# still walked by the destructive / install / etc. detectors).
+expect_allowed "sudo -i cat ./README.md (login + actual cmd, walked normally)" \
+  "sudo -i cat $PROJECT/CHANGELOG.md"
+
+expect_allowed "sudo -s ls (shell + actual cmd)" \
+  "sudo -s ls $PROJECT"
+
+# True-negative: clustered shape WITHOUT shell letters.
+expect_allowed "sudo -nE cat (cluster -n + -E, no i/s)" \
+  "sudo -nE cat $PROJECT/CHANGELOG.md"
+
+# True-negative: env wrapper + sudo + benign verb.
+expect_allowed "env -u FOO sudo cat (wrapper + sudo + read)" \
+  "env -u FOO sudo cat $PROJECT/CHANGELOG.md"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -786,3 +786,89 @@ expect_allowed "nice -n 10 ssh host 'rm /etc/x' (remote dispatch)" \
   "nice -n 10 ssh host 'rm /etc/passwd_test'"
 
 echo ""
+
+# ============================================================
+# 43. Valueless sudo flags mis-classified as value-bearing
+# ------------------------------------------------------------
+# The sudo opt tables in sections 40 / 41 / 42 listed `-A` (askpass),
+# `-K` (kill-cache), `-k` (invalidate-timestamp), and `--preserve-env`
+# in the value-bearing branch — i.e. the wrapper-walk and the new
+# strip_sudo_wrapper_with_opts both consumed the next token as the
+# flag's value. But these sudo flags are VALUE-LESS (they do not take
+# an argument); skipping the next token strips the actual verb.
+#
+# Concrete bypasses Codex round-1 on PR #24 surfaced:
+#
+#   sudo -A install -m 755 src /etc/owned       (askpass valueless)
+#   sudo -k install -m 755 src /etc/owned       (invalidate-ts valueless)
+#   sudo -K install -m 755 src /etc/owned       (kill-cache valueless)
+#   sudo --preserve-env install ... /etc/owned  (long valueless)
+#   sudo -A /bin/rm /etc/passwd                 (same on /bin/rm path)
+#
+# Fix: split the sudo opt tables into a value-bearing list (`-C -D -g
+# -h -p -r -t -T -U -u`, and the long forms `--close-from --chdir
+# --group --host --prompt --role --type --command-timeout
+# --other-user --user --auth-type`) and let everything else fall
+# through to the generic value-less `-*` branch (i += 1). Applied
+# symmetrically across hooks/lib/command_name.sh,
+# hooks/lib/subcmd_flags.sh, hooks/lib/remote_dispatch.sh and
+# strip_sudo_wrapper_with_opts.
+#
+# Reported by Codex review round-1 on PR #24 (P1; same root cause as
+# `-A` / `-K` / `-k` / `--preserve-env` being mis-listed in the
+# section 40 fix from PR #23, propagated forward into sections 41 / 42).
+# ============================================================
+echo "--- 43. valueless sudo flags mis-classified as value-bearing ---"
+
+# command_name_is install bypass with valueless sudo flags.
+expect_blocked "sudo -A install -m 755 ... /etc/owned" \
+  "sudo -A install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+expect_blocked "sudo -k install -m 755 ... /etc/owned" \
+  "sudo -k install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+expect_blocked "sudo -K install -m 755 ... /etc/owned" \
+  "sudo -K install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+expect_blocked "sudo --preserve-env install -m 755 ... /etc/owned" \
+  "sudo --preserve-env install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+# strip_command_name_prefix bypass with the same flags.
+expect_blocked "sudo -A /bin/rm /etc/passwd_test" \
+  "sudo -A /bin/rm /etc/passwd_test"
+
+expect_blocked "sudo --preserve-env /bin/rm /etc/passwd_test" \
+  "sudo --preserve-env /bin/rm /etc/passwd_test"
+
+# Subcmd-flag sink bypass (section 40 territory) with valueless sudo flag.
+expect_blocked "sudo -A tar --to-command='rm /etc/x'" \
+  "sudo -A tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+expect_blocked "sudo --preserve-env tar --to-command='rm /etc/x'" \
+  "sudo --preserve-env tar -xf $PROJECT/archive.tar --to-command='rm /etc/passwd_test'"
+
+# Nested wrapper combination Codex flagged as untested.
+expect_blocked "sudo nice -n 10 install -m 755 ... /etc/owned" \
+  "sudo nice -n 10 install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+# True-negatives: legit sudo with valueless flags must remain ALLOWED.
+expect_allowed "sudo -A cat (askpass + read in-project)" \
+  "sudo -A cat $PROJECT/CHANGELOG.md"
+
+expect_allowed "sudo -k ls (invalidate-ts + benign)" \
+  "sudo -k ls $PROJECT"
+
+expect_allowed "sudo --preserve-env cat (long valueless + read)" \
+  "sudo --preserve-env cat $PROJECT/CHANGELOG.md"
+
+expect_allowed "sudo -E cat (preserve-env short, valueless)" \
+  "sudo -E cat $PROJECT/CHANGELOG.md"
+
+# Regression-pin: value-bearing forms must still consume their value.
+expect_blocked "sudo -p 'pwd:' install ... /etc/owned (-p prompt takes value)" \
+  "sudo -p 'pwd:' install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+expect_blocked "sudo -C 100 install ... /etc/owned (-C close-from takes value)" \
+  "sudo -C 100 install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -646,8 +646,9 @@ echo ""
 #
 # Two-part fix (mirror section 40):
 #
-# A. _cn_wrapper_opts_with_val table per wrapper, walked alongside
-#    the existing wrapper-skip pass in all three helpers.
+# A. _wrapper_opts_with_val table (hooks/lib/wrapper_opts.sh) per
+#    wrapper, walked alongside the existing wrapper-skip pass in all
+#    three helpers.
 #
 # B. The literal `sudo ` strip in check_single_command also strips
 #    sudo's option-value pairs (-u USER, --user=USER, etc.), so by

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -930,3 +930,72 @@ expect_allowed "sudo --chroot / ls (long-form chroot + benign)" \
   "sudo --chroot / ls $PROJECT"
 
 echo ""
+
+# ============================================================
+# 45. Empty-CMD shell-opening sudo (`sudo -i` / `sudo -s`)
+# ------------------------------------------------------------
+# When `strip_sudo_wrapper_with_opts` (commit 76cc301) consumes all
+# sudo flags and reaches the end of the token list with no positional
+# verb, it returns an empty string. Three shapes hit this:
+#
+#   sudo            bare invocation (prints usage; harmless)
+#   sudo -l|-V|-v   list creds / version / validate-only (harmless)
+#   sudo -i|-s      open a privileged interactive shell — DANGEROUS
+#   sudo --login    long-form -i (DANGEROUS)
+#   sudo --shell    long-form -s (DANGEROUS)
+#
+# The previous code didn't re-check for an empty CMD after the sudo
+# strip; downstream walkers ran on `""` and crashed (`tokens[@]:
+# unbound variable` under `set -u`) before exiting ALLOWED. Net
+# effect: a bare `bash` invocation correctly blocks (interactive
+# shell whose subsequent commands cannot be inspected), but `sudo -i`
+# (a strictly more privileged equivalent) slipped through.
+#
+# Fix: after the sudo strip, re-check for empty CMD. If empty AND
+# `_CMD_PRE_STRIP` contained `-i` / `-s` / `--login` / `--shell` as
+# a standalone token, block — same rationale as the existing bare
+# shell-execute walker. Otherwise return 0 (harmless empty).
+#
+# Reported by Codex review round-2 on PR #24 (P2 finding).
+# ============================================================
+echo "--- 45. empty-CMD shell-opening sudo ---"
+
+# Shell-opening sudo invocations must BLOCK (privileged interactive shell).
+expect_blocked "sudo -i (login shell)" \
+  "sudo -i"
+
+expect_blocked "sudo -s (shell)" \
+  "sudo -s"
+
+expect_blocked "sudo --login (long-form -i)" \
+  "sudo --login"
+
+expect_blocked "sudo --shell (long-form -s)" \
+  "sudo --shell"
+
+expect_blocked "sudo -A -i (askpass + login shell)" \
+  "sudo -A -i"
+
+expect_blocked "sudo -u root -i (user + login shell)" \
+  "sudo -u root -i"
+
+# True-negatives: harmless empty-after-strip shapes must remain ALLOWED.
+expect_allowed "bare sudo (prints usage, harmless)" \
+  "sudo"
+
+expect_allowed "sudo -l (list creds, harmless)" \
+  "sudo -l"
+
+expect_allowed "sudo -V (version, harmless)" \
+  "sudo -V"
+
+expect_allowed "sudo -v (validate timestamp, harmless)" \
+  "sudo -v"
+
+expect_allowed "sudo --list (long-form -l)" \
+  "sudo --list"
+
+expect_allowed "sudo --version (long-form -V)" \
+  "sudo --version"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -617,3 +617,103 @@ expect_allowed "env -u FOO PROJECT-relative read (no sink)" \
   "env -u FOO cat $PROJECT/CHANGELOG.md"
 
 echo ""
+
+# ============================================================
+# 41. Wrapper opt-flags before verb in command_name.sh helpers
+# ------------------------------------------------------------
+# Same root cause as section 40, different functions:
+# `strip_command_name_prefix`, `strip_command_name_quotes`, and
+# `command_name_is` in hooks/lib/command_name.sh skipped wrapper
+# tokens (sudo / env / nice / timeout / ionice / chrt) and bare
+# `-flag` tokens, but NOT a wrapper's option-with-value pairs.
+#
+# Three concrete bypasses fall out of this:
+#
+# 1. command_name_is install — the install detector is gated on
+#    the actual command-name token (by design, to avoid false-
+#    positives on `npm install` / `cargo install` / etc.). With
+#    `sudo -u root install ...`, the helper saw `-u` as a flag
+#    (skipped) and `root` as the verb; the install detector never
+#    fired and the destination was never validated.
+#
+# 2. strip_command_name_prefix — `/bin/rm` -> `rm` rewriting (so
+#    bare-name walkers match) gave up at the orphaned wrapper
+#    value. `sudo -u root /bin/rm /etc/x` left `/bin/rm` un-rewritten
+#    and the bare rm walker (`(^|\s)rm\s`) missed it.
+#
+# 3. strip_command_name_quotes — `"rm"` / `'rm'` -> `rm`,
+#    same pattern.
+#
+# Two-part fix (mirror section 40):
+#
+# A. _cn_wrapper_opts_with_val table per wrapper, walked alongside
+#    the existing wrapper-skip pass in all three helpers.
+#
+# B. The literal `sudo ` strip in check_single_command also strips
+#    sudo's option-value pairs (-u USER, --user=USER, etc.), so by
+#    the time the helpers run, `sudo -u root` has been removed
+#    entirely. Without (B) the post-sudo-strip CMD has orphaned
+#    `-u root` which the helper wrapper-walk cannot anchor (sudo
+#    is no longer in the token list). env / nice / ionice / timeout
+#    are NOT literal-stripped, so the per-wrapper opt-skip in (A)
+#    handles them on its own.
+#
+# Reported by Codex review round-4 on PR #23 (out-of-scope follow-up:
+# analogous wrapper-skip risk in command_name.sh / remote_dispatch.sh).
+# ============================================================
+echo "--- 41. wrapper opt-flags in command_name.sh helpers ---"
+
+# command_name_is install — sudo / env / nice / timeout / ionice variants.
+expect_blocked "sudo -u root install -m 755 ... /etc/owned" \
+  "sudo -u root install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+expect_blocked "env -u FOO install -m 755 ... /etc/owned" \
+  "env -u FOO install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+expect_blocked "nice -n 10 install -m 755 ... /etc/owned" \
+  "nice -n 10 install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+expect_blocked "timeout -k 5 10 install -m 755 ... /etc/owned" \
+  "timeout -k 5 10 install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+expect_blocked "ionice -c 3 install -m 755 ... /etc/owned" \
+  "ionice -c 3 install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+# strip_command_name_prefix — /bin/rm normalization under wrappers.
+expect_blocked "sudo -u root /bin/rm /etc/passwd_test" \
+  "sudo -u root /bin/rm /etc/passwd_test"
+
+expect_blocked "env -u FOO /bin/rm /etc/passwd_test" \
+  "env -u FOO /bin/rm /etc/passwd_test"
+
+expect_blocked "nice -n 10 /bin/rm /etc/passwd_test" \
+  "nice -n 10 /bin/rm /etc/passwd_test"
+
+expect_blocked "timeout -k 5 10 /bin/rm /etc/passwd_test" \
+  "timeout -k 5 10 /bin/rm /etc/passwd_test"
+
+# strip_command_name_quotes — quoted command name under wrappers.
+expect_blocked 'sudo -u root "rm" /etc/passwd_test' \
+  "sudo -u root \"rm\" /etc/passwd_test"
+
+expect_blocked "nice -n 10 'rm' /etc/passwd_test" \
+  "nice -n 10 'rm' /etc/passwd_test"
+
+# Long-form attached opt: --user=root must also be skipped from sudo.
+expect_blocked "sudo --user=root install -m 755 ... /etc/owned" \
+  "sudo --user=root install -m 755 $PROJECT/CHANGELOG.md /etc/passwd_test"
+
+# True-negatives: legit reads / non-destructive uses must remain ALLOWED.
+expect_allowed "sudo -u root cat (read in-project)" \
+  "sudo -u root cat $PROJECT/CHANGELOG.md"
+
+expect_allowed "env -u FOO cat (read in-project)" \
+  "env -u FOO cat $PROJECT/CHANGELOG.md"
+
+expect_allowed "env -u FOO npm install (npm subcmd, not GNU install)" \
+  "env -u FOO npm install"
+
+expect_allowed "nice -n 10 ls (benign command)" \
+  "nice -n 10 ls $PROJECT"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -717,3 +717,72 @@ expect_allowed "nice -n 10 ls (benign command)" \
   "nice -n 10 ls $PROJECT"
 
 echo ""
+
+# ============================================================
+# 42. Wrapper opt-flags before verb in remote_dispatch.sh
+# ------------------------------------------------------------
+# Final piece of the same wrapper-opt-flag root cause: `_rd_find_verb_idx`
+# in hooks/lib/remote_dispatch.sh skipped wrapper tokens (sudo / env /
+# nice / timeout / ionice) and bare `-flag` tokens, but NOT a wrapper's
+# option-with-value pairs. With `env -u FOO docker exec ctr rm -rf /`
+# the verb-finder treated `FOO` as the verb (not `docker`) and the
+# `docker exec` neutralisation never fired — leaving the foreign-fs
+# `rm -rf /` visible to the bare rm walker, which over-blocked the
+# (legitimate) container-side cleanup.
+#
+# Direction is OVER-block, not bypass: the broken neutralisation
+# leaves remote command strings exposed to the local-fs walkers, so
+# the failure mode is "false positive on legitimate `docker exec` /
+# `kubectl exec` / `ssh` invocations". The fix tightens the verb-
+# finder so the dispatch class is recognised and the cmd is correctly
+# collapsed before the local walkers run.
+#
+# Sudo cases are already covered by section 41's sudo-strip-with-opts
+# (sudo + opts are gone before rewrite_remote_dispatch sees CMD). This
+# section pins env / nice / timeout / ionice variants and keeps a
+# regression test for the kubectl cp download path that must stay
+# BLOCKED.
+#
+# Reported by Codex review round-4 on PR #23 (out-of-scope follow-up).
+# ============================================================
+echo "--- 42. wrapper opt-flags in remote_dispatch.sh ---"
+
+# Over-block fix: docker exec / kubectl exec must collapse cleanly so
+# the foreign-fs verb body is NOT walked by local-path walkers.
+expect_allowed "env -u FOO docker exec ctr rm -rf / (foreign fs)" \
+  "env -u FOO docker exec ctr rm -rf /"
+
+expect_allowed "nice -n 10 docker exec ctr rm -rf / (foreign fs)" \
+  "nice -n 10 docker exec ctr rm -rf /"
+
+expect_allowed "timeout -k 5 10 docker exec ctr rm -rf / (foreign fs)" \
+  "timeout -k 5 10 docker exec ctr rm -rf /"
+
+expect_allowed "ionice -c 3 docker exec ctr rm -rf / (foreign fs)" \
+  "ionice -c 3 docker exec ctr rm -rf /"
+
+expect_allowed "env -u FOO kubectl exec pod -- rm -rf / (foreign fs)" \
+  "env -u FOO kubectl exec pod -- rm -rf /"
+
+expect_allowed "nice -n 10 kubectl exec pod -- rm -rf / (foreign fs)" \
+  "nice -n 10 kubectl exec pod -- rm -rf /"
+
+# Regression-pin: even with the fix, kubectl cp / docker cp DOWNLOAD to
+# a host destination must STILL block. The remote-copy rewrite
+# (_rd_rewrite_remote_copy) emits a synthetic `cp <local-dst>` so the
+# cp walker validates the host-side write target.
+expect_blocked "env -u FOO kubectl cp pod:/x /etc/owned (download)" \
+  "env -u FOO kubectl cp pod:/x /etc/passwd_test"
+
+expect_blocked "nice -n 10 docker cp ctr:/x /etc/owned (download)" \
+  "nice -n 10 docker cp ctr:/x /etc/passwd_test"
+
+# True-negative: ssh remote command stays ALLOWED — the cmd runs on
+# the remote host and the local fs is not the target.
+expect_allowed "env -u FOO ssh host 'rm /etc/x' (remote dispatch)" \
+  "env -u FOO ssh host 'rm /etc/passwd_test'"
+
+expect_allowed "nice -n 10 ssh host 'rm /etc/x' (remote dispatch)" \
+  "nice -n 10 ssh host 'rm /etc/passwd_test'"
+
+echo ""

--- a/tests/test_bypass_reproducers_flags.sh
+++ b/tests/test_bypass_reproducers_flags.sh
@@ -1143,3 +1143,27 @@ expect_allowed "env -u FOO sudo cat (wrapper + sudo + read)" \
   "env -u FOO sudo cat $PROJECT/CHANGELOG.md"
 
 echo ""
+
+# ============================================================
+# 48. Shell-opening sudo: long-form valueless flag before -i / -s
+# ------------------------------------------------------------
+# Phase 2 of `_cn_is_sudo_shell_opener` matches `-[A-Za-z]*` for
+# clustered shorts but falls through to `*) return 1` on long-form
+# valueless flags (`--preserve-env`, `--background`, `--set-home`,
+# ...) — they don't match `--*=*` (no `=`) nor `-[A-Za-z]*` (start
+# with `--`). Phase 2 then mis-treats them as a positional verb and
+# bails before seeing the shell-opener that follows.
+# Fix: `-*` catch-all before `*) return 1`.
+# ============================================================
+echo "--- 48. shell-opening sudo: long-form valueless flag before -i/-s ---"
+
+expect_blocked "sudo --preserve-env -i" "sudo --preserve-env -i"
+expect_blocked "sudo --background -s" "sudo --background -s"
+expect_blocked "sudo --non-interactive -i" "sudo --non-interactive -i"
+expect_blocked "env -u FOO sudo --preserve-env -i" "env -u FOO sudo --preserve-env -i"
+expect_blocked "sudo --preserve-env -ni (cluster after long valueless)" "sudo --preserve-env -ni"
+
+expect_allowed "sudo --preserve-env cat (long valueless + read)" \
+  "sudo --preserve-env cat $PROJECT/CHANGELOG.md"
+
+echo ""


### PR DESCRIPTION
## Summary

Closes the wrapper-opt-flag bypass class introduced in PR #23 (sec 40, `subcmd_flags.sh`), propagating the same fix across `command_name.sh` and `remote_dispatch.sh`. Plus 6 follow-up rounds of Codex review (sec 43–48) covering missing/excess sudo value-bearing flags and shell-opening sudo edge cases. Final commit deduplicates the three wrapper-opts tables.

**Bypass class:** wrapper opt-flag values were treated as the verb. `sudo -u root install ... /etc/owned` mis-identified `root` as the verb, so `command_name_is install` returned false and the install detector never validated the destination. Same shape for `strip_command_name_prefix` (`/bin/rm` not normalised), `strip_command_name_quotes` (`"rm"` not unquoted), and `_rd_find_verb_idx` (docker-exec / kubectl-exec not neutralised → over-block on legit foreign-fs cmds).

## Sections

| Section | Bypass | Source | BLOCKED reproducers | ALLOWED true-negatives |
|---|---|---|---|---|
| 41 | `command_name.sh` wrapper opt-flags | Codex round 4 / PR #23 | 11 | 4 |
| 42 | `remote_dispatch.sh` wrapper opt-flags | Codex round 4 / PR #23 | 2 | 8 |
| 43 | Valueless sudo flags mis-classified as value-bearing (`-A` / `-K` / `-k` / `--preserve-env`) | Codex round 1 / PR #24 | 9 | 6 |
| 44 | Missing sudo value-bearing flags `-a` / `-R` / `--chroot` | Codex round 2 / PR #24 | 6 | 3 |
| 45 | Empty-CMD shell-opening sudo (`sudo -i` / `-s` / `--login` / `--shell`) | Codex round 2 / PR #24 | 6 | 6 |
| 46 | Missing sudo value-bearing flag `-c` / `--login-class` | Codex round 3 / PR #24 | 4 | 2 |
| 47 | Shell-opening sudo: clustered (`-ni`/`-nis`) / quoted / wrapper-prefixed | Codex round 3 / PR #24 | 14 | 4 |
| 48 | Shell-opening sudo: long-form valueless flag before `-i`/`-s` (`sudo --preserve-env -i`) | Self-review | 5 | 1 |

## Refactor (final commit)

The three identical `_cn_/_sf_/_rd_wrapper_opts_with_val` tables in `command_name.sh` / `subcmd_flags.sh` / `remote_dispatch.sh` were a maintenance hazard — every Codex round adding a sudo flag had to update three places. Extracted to `hooks/lib/wrapper_opts.sh` (single `_wrapper_opts_with_val()` helper). Net **-72 lines**. Verb-finder loops keep their per-module names (still need module-private array access; bash 3.2 / no namerefs).

## TDD discipline

All bypass-closing commits follow CLAUDE.md §Security-bypass TDD flow: reproducers added first, confirmed FAILing pre-fix, then patch landed, then full suite green. Behaviour-pins for already-working forms kept as regression guards.

## Test plan

- [x] `bash tests/test_guard.sh` — **1062/1062 PASS**
- [x] All 8 sections (41–48) reproducers + true-negatives + regression-pins
- [x] Refactor doesn't change test count (1062 → 1062)
- [ ] CI on macos-latest + ubuntu-latest

Generated with Claude Code.
