### PR TITLE
[verify only — DO NOT MERGE] F10 empirical pre-fix demonstration for #31

### DIFF
--- a/hooks/guard.sh
+++ b/hooks/guard.sh
@@ -373,10 +373,6 @@ if [ -n "$FILE_PATH" ]; then
   if [[ -e "$RESOLVED" ]]; then
     RESOLVED="$(cd "$(dirname "$RESOLVED")" && pwd -P)/$(basename "$RESOLVED")"
   fi
-  # NTFS reparse points (junctions / mklink /J) are NOT POSIX symlinks
-  # so the chase loop above misses them. Walk ancestors and refuse if
-  # any is a reparse point (#31). No-op on Linux/macOS.
-  assert_no_unsafe_reparse "$RESOLVED" "file_path"
   if ! is_write_permitted "$RESOLVED"; then
     echo "BLOCKED: File '$RESOLVED' is OUTSIDE project directory '$PROJECT_DIR'. Ask user for explicit permission." >&2
     exit 2

--- a/hooks/lib/paths.sh
+++ b/hooks/lib/paths.sh
@@ -340,47 +340,11 @@ block_unless_path_allowed() {
   exit 2
 }
 
-# --- Refuse paths that traverse an NTFS reparse point ---
-# On Windows MSYS2, `mklink /J` directory junctions (and `mklink /D`
-# symbolic links created without SeCreateSymbolicLink privilege) are
-# NTFS reparse points, NOT POSIX symlinks. `readlink` returns nothing
-# for them and `[[ -L ... ]]` is FALSE, so the symlink-chase loops in
-# guard.sh / resolve_path skip them. An in-project junction pointing
-# outside the project (e.g. `project/junk -> C:\Windows`) silently
-# bypasses the boundary check otherwise.
-#
-# Walks PATH upward toward filesystem root, checks each existing
-# component via `fsutil.exe reparsepoint query`. First reparse-point
-# hit → BLOCKED + exit 2 (fail-closed: refuse to resolve, don't try
-# to chase the NTFS target).
-#
-# Linux/macOS: cygpath/fsutil absent → returns silently, zero cost.
-assert_no_unsafe_reparse() {
-  local path="$1" label="$2"
-  command -v cygpath >/dev/null 2>&1 || return 0
-  command -v fsutil.exe >/dev/null 2>&1 || return 0
-  local cur="$path"
-  while [ -n "$cur" ] && [ "$cur" != "/" ] && [ "$cur" != "." ]; do
-    if [ -e "$cur" ]; then
-      local _win
-      _win=$(cygpath -wa "$cur" 2>/dev/null || true)
-      if [ -n "$_win" ]; then
-        if fsutil.exe reparsepoint query "$_win" 2>/dev/null | grep -q "Reparse Tag Value"; then
-          echo "BLOCKED: '$label' traverses an NTFS reparse point at '$cur' (junction or symlink). Ask user for explicit permission." >&2
-          exit 2
-        fi
-      fi
-    fi
-    cur=$(dirname "$cur")
-  done
-}
-
 # validate_command_path POLICY LABEL RAW_PATH
 # Convenience wrapper: resolve + check in one call. Most call-sites
 # only need this single helper.
 validate_command_path() {
   local resolved
   resolved=$(resolve_command_path "$3")
-  assert_no_unsafe_reparse "$resolved" "$2"
   block_unless_path_allowed "$1" "$2" "$resolved"
 }


### PR DESCRIPTION
Reverts sec 115 fix (9bd8ffc) to empirically demonstrate that the junction reproducer in 584045f/84fefd4 actually fails without the assert_no_unsafe_reparse helper. Per anti-facade skill v2.1.0 F10 requirement: smoking-gun must be empirically executed, not declared.

Expected: Windows smoke job FAILS on the 3 junction expect_blocked assertions.

This PR will be closed without merging once the failure is recorded.